### PR TITLE
Improving Instagram 1.0 typesystem and fixing examples.

### DIFF
--- a/src/source/TCK/RAML10/Instagram1.0/api-tck.json
+++ b/src/source/TCK/RAML10/Instagram1.0/api-tck.json
@@ -531,7 +531,17 @@
                           ],
                           "count": 2
                         },
-                        "caption": null,
+                        "caption": {
+                          "created_time": "1296710352",
+                          "text": "Inside le truc #foodtruck",
+                          "from": {
+                            "username": "kevin",
+                            "full_name": "Kevin Systrom",
+                            "type": "user",
+                            "id": "3"
+                          },
+                          "id": "26621408"
+                        },
                         "likes": {
                           "count": 1,
                           "data": [
@@ -571,7 +581,12 @@
                           }
                         },
                         "id": "3",
-                        "location": null
+                        "location": {
+                          "id": "id",
+                          "latitude": -34,
+                          "longitude": -53,
+                          "name": "some place"
+                        }
                       }
                     },
                     "repeat": false,
@@ -626,7 +641,17 @@
                             ],
                             "count": 2
                           },
-                          "caption": null,
+                          "caption": {
+                            "created_time": "1296710352",
+                            "text": "Inside le truc #foodtruck",
+                            "from": {
+                              "username": "kevin",
+                              "full_name": "Kevin Systrom",
+                              "type": "user",
+                              "id": "3"
+                            },
+                            "id": "26621408"
+                          },
                           "likes": {
                             "count": 1,
                             "data": [
@@ -666,7 +691,12 @@
                             }
                           },
                           "id": "3",
-                          "location": null
+                          "location": {
+                            "id": "id",
+                            "latitude": -34,
+                            "longitude": -53,
+                            "name": "some place"
+                          }
                         }
                       },
                       "strict": true,
@@ -707,7 +737,17 @@
                             ],
                             "count": 2
                           },
-                          "caption": null,
+                          "caption": {
+                            "created_time": "1296710352",
+                            "text": "Inside le truc #foodtruck",
+                            "from": {
+                              "username": "kevin",
+                              "full_name": "Kevin Systrom",
+                              "type": "user",
+                              "id": "3"
+                            },
+                            "id": "26621408"
+                          },
                           "likes": {
                             "count": 1,
                             "data": [
@@ -747,7 +787,12 @@
                             }
                           },
                           "id": "3",
-                          "location": null
+                          "location": {
+                            "id": "id",
+                            "latitude": -34,
+                            "longitude": -53,
+                            "name": "some place"
+                          }
                         }
                       }
                     }
@@ -1037,13 +1082,24 @@
                             "id": "833",
                             "latitude": 37.77956816727314,
                             "longitude": -122.4138736724854,
+                            "street_address": "",
                             "name": "Civic Center BART"
                           },
                           "comments": {
                             "count": 16,
                             "data": []
                           },
-                          "caption": null,
+                          "caption": {
+                            "created_time": "1296710352",
+                            "text": "Inside le truc #foodtruck",
+                            "from": {
+                              "username": "kevin",
+                              "full_name": "Kevin Systrom",
+                              "type": "user",
+                              "id": "3"
+                            },
+                            "id": "26621408"
+                          },
                           "link": "http://instagr.am/p/BXsFz/",
                           "likes": {
                             "count": 190,
@@ -1076,7 +1132,20 @@
                             }
                           },
                           "type": "image",
-                          "users_in_photo": [],
+                          "users_in_photo": [
+                            {
+                              "user": {
+                                "username": "kevin",
+                                "full_name": "Kevin S",
+                                "id": "3",
+                                "profile_picture": "..."
+                              },
+                              "position": {
+                                "x": 0.315,
+                                "y": 0.9111
+                              }
+                            }
+                          ],
                           "filter": "Earlybird",
                           "tags": [],
                           "id": "22987123",
@@ -1127,7 +1196,17 @@
                               ],
                               "count": 2
                             },
-                            "caption": null,
+                            "caption": {
+                              "created_time": "1296710352",
+                              "text": "Inside le truc #foodtruck",
+                              "from": {
+                                "username": "kevin",
+                                "full_name": "Kevin Systrom",
+                                "type": "user",
+                                "id": "3"
+                              },
+                              "id": "26621408"
+                            },
                             "likes": {
                               "count": 1,
                               "data": [
@@ -1159,7 +1238,7 @@
                               }
                             },
                             "type": "video",
-                            "users_in_photo": null,
+                            "users_in_photo": [],
                             "filter": "Vesper",
                             "tags": [],
                             "id": "363839373298",
@@ -1169,7 +1248,13 @@
                               "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                               "id": "3"
                             },
-                            "location": null
+                            "location": {
+                              "id": "833",
+                              "latitude": 37.77956816727314,
+                              "longitude": -122.4138736724854,
+                              "street_address": "",
+                              "name": "Civic Center BART"
+                            }
                           }
                         }
                       ]
@@ -1198,13 +1283,24 @@
                               "id": "833",
                               "latitude": 37.77956816727314,
                               "longitude": -122.4138736724854,
+                              "street_address": "",
                               "name": "Civic Center BART"
                             },
                             "comments": {
                               "count": 16,
                               "data": []
                             },
-                            "caption": null,
+                            "caption": {
+                              "created_time": "1296710352",
+                              "text": "Inside le truc #foodtruck",
+                              "from": {
+                                "username": "kevin",
+                                "full_name": "Kevin Systrom",
+                                "type": "user",
+                                "id": "3"
+                              },
+                              "id": "26621408"
+                            },
                             "link": "http://instagr.am/p/BXsFz/",
                             "likes": {
                               "count": 190,
@@ -1237,7 +1333,20 @@
                               }
                             },
                             "type": "image",
-                            "users_in_photo": [],
+                            "users_in_photo": [
+                              {
+                                "user": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin S",
+                                  "id": "3",
+                                  "profile_picture": "..."
+                                },
+                                "position": {
+                                  "x": 0.315,
+                                  "y": 0.9111
+                                }
+                              }
+                            ],
                             "filter": "Earlybird",
                             "tags": [],
                             "id": "22987123",
@@ -1288,7 +1397,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -1320,7 +1439,7 @@
                                 }
                               },
                               "type": "video",
-                              "users_in_photo": null,
+                              "users_in_photo": [],
                               "filter": "Vesper",
                               "tags": [],
                               "id": "363839373298",
@@ -1330,7 +1449,13 @@
                                 "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                 "id": "3"
                               },
-                              "location": null
+                              "location": {
+                                "id": "833",
+                                "latitude": 37.77956816727314,
+                                "longitude": -122.4138736724854,
+                                "street_address": "",
+                                "name": "Civic Center BART"
+                              }
                             }
                           }
                         ]
@@ -1345,13 +1470,24 @@
                               "id": "833",
                               "latitude": 37.77956816727314,
                               "longitude": -122.4138736724854,
+                              "street_address": "",
                               "name": "Civic Center BART"
                             },
                             "comments": {
                               "count": 16,
                               "data": []
                             },
-                            "caption": null,
+                            "caption": {
+                              "created_time": "1296710352",
+                              "text": "Inside le truc #foodtruck",
+                              "from": {
+                                "username": "kevin",
+                                "full_name": "Kevin Systrom",
+                                "type": "user",
+                                "id": "3"
+                              },
+                              "id": "26621408"
+                            },
                             "link": "http://instagr.am/p/BXsFz/",
                             "likes": {
                               "count": 190,
@@ -1384,7 +1520,20 @@
                               }
                             },
                             "type": "image",
-                            "users_in_photo": [],
+                            "users_in_photo": [
+                              {
+                                "user": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin S",
+                                  "id": "3",
+                                  "profile_picture": "..."
+                                },
+                                "position": {
+                                  "x": 0.315,
+                                  "y": 0.9111
+                                }
+                              }
+                            ],
                             "filter": "Earlybird",
                             "tags": [],
                             "id": "22987123",
@@ -1435,7 +1584,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -1467,7 +1626,7 @@
                                 }
                               },
                               "type": "video",
-                              "users_in_photo": null,
+                              "users_in_photo": [],
                               "filter": "Vesper",
                               "tags": [],
                               "id": "363839373298",
@@ -1477,7 +1636,13 @@
                                 "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                 "id": "3"
                               },
-                              "location": null
+                              "location": {
+                                "id": "833",
+                                "latitude": 37.77956816727314,
+                                "longitude": -122.4138736724854,
+                                "street_address": "",
+                                "name": "Civic Center BART"
+                              }
                             }
                           }
                         ]
@@ -2810,7 +2975,17 @@
                               ],
                               "count": 2
                             },
-                            "caption": null,
+                            "caption": {
+                              "created_time": "1296710352",
+                              "text": "Inside le truc #foodtruck",
+                              "from": {
+                                "username": "kevin",
+                                "full_name": "Kevin Systrom",
+                                "type": "user",
+                                "id": "3"
+                              },
+                              "id": "26621408"
+                            },
                             "likes": {
                               "count": 1,
                               "data": [
@@ -2850,7 +3025,12 @@
                               }
                             },
                             "id": "3",
-                            "location": null
+                            "location": {
+                              "id": "id",
+                              "latitude": -34,
+                              "longitude": -53,
+                              "name": "some place"
+                            }
                           }
                         },
                         "repeat": false,
@@ -2905,7 +3085,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -2945,7 +3135,12 @@
                                 }
                               },
                               "id": "3",
-                              "location": null
+                              "location": {
+                                "id": "id",
+                                "latitude": -34,
+                                "longitude": -53,
+                                "name": "some place"
+                              }
                             }
                           },
                           "strict": true,
@@ -2986,7 +3181,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -3026,7 +3231,12 @@
                                 }
                               },
                               "id": "3",
-                              "location": null
+                              "location": {
+                                "id": "id",
+                                "latitude": -34,
+                                "longitude": -53,
+                                "name": "some place"
+                              }
                             }
                           }
                         }
@@ -3200,7 +3410,17 @@
                               ],
                               "count": 2
                             },
-                            "caption": null,
+                            "caption": {
+                              "created_time": "1296710352",
+                              "text": "Inside le truc #foodtruck",
+                              "from": {
+                                "username": "kevin",
+                                "full_name": "Kevin Systrom",
+                                "type": "user",
+                                "id": "3"
+                              },
+                              "id": "26621408"
+                            },
                             "likes": {
                               "count": 1,
                               "data": [
@@ -3240,7 +3460,12 @@
                               }
                             },
                             "id": "3",
-                            "location": null
+                            "location": {
+                              "id": "id",
+                              "latitude": -34,
+                              "longitude": -53,
+                              "name": "some place"
+                            }
                           }
                         },
                         "repeat": false,
@@ -3295,7 +3520,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -3335,7 +3570,12 @@
                                 }
                               },
                               "id": "3",
-                              "location": null
+                              "location": {
+                                "id": "id",
+                                "latitude": -34,
+                                "longitude": -53,
+                                "name": "some place"
+                              }
                             }
                           },
                           "strict": true,
@@ -3376,7 +3616,17 @@
                                 ],
                                 "count": 2
                               },
-                              "caption": null,
+                              "caption": {
+                                "created_time": "1296710352",
+                                "text": "Inside le truc #foodtruck",
+                                "from": {
+                                  "username": "kevin",
+                                  "full_name": "Kevin Systrom",
+                                  "type": "user",
+                                  "id": "3"
+                                },
+                                "id": "26621408"
+                              },
                               "likes": {
                                 "count": 1,
                                 "data": [
@@ -3416,7 +3666,12 @@
                                 }
                               },
                               "id": "3",
-                              "location": null
+                              "location": {
+                                "id": "id",
+                                "latitude": -34,
+                                "longitude": -53,
+                                "name": "some place"
+                              }
                             }
                           }
                         }
@@ -4875,13 +5130,24 @@
                                     "id": "833",
                                     "latitude": 37.77956816727314,
                                     "longitude": -122.4138736724854,
+                                    "street_address": "",
                                     "name": "Civic Center BART"
                                   },
                                   "comments": {
                                     "count": 16,
                                     "data": []
                                   },
-                                  "caption": null,
+                                  "caption": {
+                                    "created_time": "1296710352",
+                                    "text": "Inside le truc #foodtruck",
+                                    "from": {
+                                      "username": "kevin",
+                                      "full_name": "Kevin Systrom",
+                                      "type": "user",
+                                      "id": "3"
+                                    },
+                                    "id": "26621408"
+                                  },
                                   "link": "http://instagr.am/p/BXsFz/",
                                   "likes": {
                                     "count": 190,
@@ -4914,7 +5180,20 @@
                                     }
                                   },
                                   "type": "image",
-                                  "users_in_photo": [],
+                                  "users_in_photo": [
+                                    {
+                                      "user": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin S",
+                                        "id": "3",
+                                        "profile_picture": "..."
+                                      },
+                                      "position": {
+                                        "x": 0.315,
+                                        "y": 0.9111
+                                      }
+                                    }
+                                  ],
                                   "filter": "Earlybird",
                                   "tags": [],
                                   "id": "22987123",
@@ -4965,7 +5244,17 @@
                                       ],
                                       "count": 2
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "likes": {
                                       "count": 1,
                                       "data": [
@@ -4997,7 +5286,7 @@
                                       }
                                     },
                                     "type": "video",
-                                    "users_in_photo": null,
+                                    "users_in_photo": [],
                                     "filter": "Vesper",
                                     "tags": [],
                                     "id": "363839373298",
@@ -5007,7 +5296,13 @@
                                       "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                       "id": "3"
                                     },
-                                    "location": null
+                                    "location": {
+                                      "id": "833",
+                                      "latitude": 37.77956816727314,
+                                      "longitude": -122.4138736724854,
+                                      "street_address": "",
+                                      "name": "Civic Center BART"
+                                    }
                                   }
                                 }
                               ]
@@ -5036,13 +5331,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -5075,7 +5381,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -5126,7 +5445,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -5158,7 +5487,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -5168,7 +5497,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -5183,13 +5518,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -5222,7 +5568,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -5273,7 +5632,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -5305,7 +5674,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -5315,7 +5684,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -6235,13 +6610,24 @@
                                     "id": "833",
                                     "latitude": 37.77956816727314,
                                     "longitude": -122.4138736724854,
+                                    "street_address": "",
                                     "name": "Civic Center BART"
                                   },
                                   "comments": {
                                     "count": 16,
                                     "data": []
                                   },
-                                  "caption": null,
+                                  "caption": {
+                                    "created_time": "1296710352",
+                                    "text": "Inside le truc #foodtruck",
+                                    "from": {
+                                      "username": "kevin",
+                                      "full_name": "Kevin Systrom",
+                                      "type": "user",
+                                      "id": "3"
+                                    },
+                                    "id": "26621408"
+                                  },
                                   "link": "http://instagr.am/p/BXsFz/",
                                   "likes": {
                                     "count": 190,
@@ -6274,7 +6660,20 @@
                                     }
                                   },
                                   "type": "image",
-                                  "users_in_photo": [],
+                                  "users_in_photo": [
+                                    {
+                                      "user": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin S",
+                                        "id": "3",
+                                        "profile_picture": "..."
+                                      },
+                                      "position": {
+                                        "x": 0.315,
+                                        "y": 0.9111
+                                      }
+                                    }
+                                  ],
                                   "filter": "Earlybird",
                                   "tags": [],
                                   "id": "22987123",
@@ -6325,7 +6724,17 @@
                                       ],
                                       "count": 2
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "likes": {
                                       "count": 1,
                                       "data": [
@@ -6357,7 +6766,7 @@
                                       }
                                     },
                                     "type": "video",
-                                    "users_in_photo": null,
+                                    "users_in_photo": [],
                                     "filter": "Vesper",
                                     "tags": [],
                                     "id": "363839373298",
@@ -6367,7 +6776,13 @@
                                       "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                       "id": "3"
                                     },
-                                    "location": null
+                                    "location": {
+                                      "id": "833",
+                                      "latitude": 37.77956816727314,
+                                      "longitude": -122.4138736724854,
+                                      "street_address": "",
+                                      "name": "Civic Center BART"
+                                    }
                                   }
                                 }
                               ]
@@ -6396,13 +6811,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -6435,7 +6861,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -6486,7 +6925,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -6518,7 +6967,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -6528,7 +6977,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -6543,13 +6998,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -6582,7 +7048,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -6633,7 +7112,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -6665,7 +7154,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -6675,7 +7164,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -7085,13 +7580,24 @@
                                     "id": "833",
                                     "latitude": 37.77956816727314,
                                     "longitude": -122.4138736724854,
+                                    "street_address": "",
                                     "name": "Civic Center BART"
                                   },
                                   "comments": {
                                     "count": 16,
                                     "data": []
                                   },
-                                  "caption": null,
+                                  "caption": {
+                                    "created_time": "1296710352",
+                                    "text": "Inside le truc #foodtruck",
+                                    "from": {
+                                      "username": "kevin",
+                                      "full_name": "Kevin Systrom",
+                                      "type": "user",
+                                      "id": "3"
+                                    },
+                                    "id": "26621408"
+                                  },
                                   "link": "http://instagr.am/p/BXsFz/",
                                   "likes": {
                                     "count": 190,
@@ -7124,7 +7630,20 @@
                                     }
                                   },
                                   "type": "image",
-                                  "users_in_photo": [],
+                                  "users_in_photo": [
+                                    {
+                                      "user": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin S",
+                                        "id": "3",
+                                        "profile_picture": "..."
+                                      },
+                                      "position": {
+                                        "x": 0.315,
+                                        "y": 0.9111
+                                      }
+                                    }
+                                  ],
                                   "filter": "Earlybird",
                                   "tags": [],
                                   "id": "22987123",
@@ -7175,7 +7694,17 @@
                                       ],
                                       "count": 2
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "likes": {
                                       "count": 1,
                                       "data": [
@@ -7207,7 +7736,7 @@
                                       }
                                     },
                                     "type": "video",
-                                    "users_in_photo": null,
+                                    "users_in_photo": [],
                                     "filter": "Vesper",
                                     "tags": [],
                                     "id": "363839373298",
@@ -7217,7 +7746,13 @@
                                       "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                       "id": "3"
                                     },
-                                    "location": null
+                                    "location": {
+                                      "id": "833",
+                                      "latitude": 37.77956816727314,
+                                      "longitude": -122.4138736724854,
+                                      "street_address": "",
+                                      "name": "Civic Center BART"
+                                    }
                                   }
                                 }
                               ]
@@ -7246,13 +7781,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -7285,7 +7831,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -7336,7 +7895,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -7368,7 +7937,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -7378,7 +7947,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -7393,13 +7968,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -7432,7 +8018,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -7483,7 +8082,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -7515,7 +8124,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -7525,7 +8134,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -7957,13 +8572,24 @@
                                     "id": "833",
                                     "latitude": 37.77956816727314,
                                     "longitude": -122.4138736724854,
+                                    "street_address": "",
                                     "name": "Civic Center BART"
                                   },
                                   "comments": {
                                     "count": 16,
                                     "data": []
                                   },
-                                  "caption": null,
+                                  "caption": {
+                                    "created_time": "1296710352",
+                                    "text": "Inside le truc #foodtruck",
+                                    "from": {
+                                      "username": "kevin",
+                                      "full_name": "Kevin Systrom",
+                                      "type": "user",
+                                      "id": "3"
+                                    },
+                                    "id": "26621408"
+                                  },
                                   "link": "http://instagr.am/p/BXsFz/",
                                   "likes": {
                                     "count": 190,
@@ -7996,7 +8622,20 @@
                                     }
                                   },
                                   "type": "image",
-                                  "users_in_photo": [],
+                                  "users_in_photo": [
+                                    {
+                                      "user": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin S",
+                                        "id": "3",
+                                        "profile_picture": "..."
+                                      },
+                                      "position": {
+                                        "x": 0.315,
+                                        "y": 0.9111
+                                      }
+                                    }
+                                  ],
                                   "filter": "Earlybird",
                                   "tags": [],
                                   "id": "22987123",
@@ -8047,7 +8686,17 @@
                                       ],
                                       "count": 2
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "likes": {
                                       "count": 1,
                                       "data": [
@@ -8079,7 +8728,7 @@
                                       }
                                     },
                                     "type": "video",
-                                    "users_in_photo": null,
+                                    "users_in_photo": [],
                                     "filter": "Vesper",
                                     "tags": [],
                                     "id": "363839373298",
@@ -8089,7 +8738,13 @@
                                       "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                       "id": "3"
                                     },
-                                    "location": null
+                                    "location": {
+                                      "id": "833",
+                                      "latitude": 37.77956816727314,
+                                      "longitude": -122.4138736724854,
+                                      "street_address": "",
+                                      "name": "Civic Center BART"
+                                    }
                                   }
                                 }
                               ]
@@ -8118,13 +8773,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -8157,7 +8823,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -8208,7 +8887,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -8240,7 +8929,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -8250,7 +8939,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]
@@ -8265,13 +8960,24 @@
                                       "id": "833",
                                       "latitude": 37.77956816727314,
                                       "longitude": -122.4138736724854,
+                                      "street_address": "",
                                       "name": "Civic Center BART"
                                     },
                                     "comments": {
                                       "count": 16,
                                       "data": []
                                     },
-                                    "caption": null,
+                                    "caption": {
+                                      "created_time": "1296710352",
+                                      "text": "Inside le truc #foodtruck",
+                                      "from": {
+                                        "username": "kevin",
+                                        "full_name": "Kevin Systrom",
+                                        "type": "user",
+                                        "id": "3"
+                                      },
+                                      "id": "26621408"
+                                    },
                                     "link": "http://instagr.am/p/BXsFz/",
                                     "likes": {
                                       "count": 190,
@@ -8304,7 +9010,20 @@
                                       }
                                     },
                                     "type": "image",
-                                    "users_in_photo": [],
+                                    "users_in_photo": [
+                                      {
+                                        "user": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin S",
+                                          "id": "3",
+                                          "profile_picture": "..."
+                                        },
+                                        "position": {
+                                          "x": 0.315,
+                                          "y": 0.9111
+                                        }
+                                      }
+                                    ],
                                     "filter": "Earlybird",
                                     "tags": [],
                                     "id": "22987123",
@@ -8355,7 +9074,17 @@
                                         ],
                                         "count": 2
                                       },
-                                      "caption": null,
+                                      "caption": {
+                                        "created_time": "1296710352",
+                                        "text": "Inside le truc #foodtruck",
+                                        "from": {
+                                          "username": "kevin",
+                                          "full_name": "Kevin Systrom",
+                                          "type": "user",
+                                          "id": "3"
+                                        },
+                                        "id": "26621408"
+                                      },
                                       "likes": {
                                         "count": 1,
                                         "data": [
@@ -8387,7 +9116,7 @@
                                         }
                                       },
                                       "type": "video",
-                                      "users_in_photo": null,
+                                      "users_in_photo": [],
                                       "filter": "Vesper",
                                       "tags": [],
                                       "id": "363839373298",
@@ -8397,7 +9126,13 @@
                                         "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
                                         "id": "3"
                                       },
-                                      "location": null
+                                      "location": {
+                                        "id": "833",
+                                        "latitude": 37.77956816727314,
+                                        "longitude": -122.4138736724854,
+                                        "street_address": "",
+                                        "name": "Civic Center BART"
+                                      }
                                     }
                                   }
                                 ]

--- a/src/source/TCK/RAML10/Instagram1.0/examples/feed-example.json
+++ b/src/source/TCK/RAML10/Instagram1.0/examples/feed-example.json
@@ -5,13 +5,24 @@
             "id": "833",
             "latitude": 37.77956816727314,
             "longitude": -122.41387367248539,
+            "street_address": "",
             "name": "Civic Center BART"
         },
         "comments": {
             "count": 16,
             "data": [  ]
         },
-        "caption": "some caption",
+        "caption":  {
+            "created_time": "1296710352",
+            "text": "Inside le truc #foodtruck",
+            "from": {
+                "username": "kevin",
+                "full_name": "Kevin Systrom",
+                "type": "user",
+                "id": "3"
+            },
+            "id": "26621408"
+        },
         "link": "http://instagr.am/p/BXsFz/",
         "likes": {
             "count": 190,
@@ -41,7 +52,18 @@
             }
         },
         "type": "image",
-        "users_in_photo": [],
+        "users_in_photo": [{
+            "user": {
+                "username": "kevin",
+                "full_name": "Kevin S",
+                "id": "3",
+                "profile_picture": "..."
+            },
+            "position": {
+                "x": 0.315,
+                "y": 0.9111
+            }
+        }],
         "filter": "Earlybird",
         "tags": [],
         "id": "22987123",
@@ -64,8 +86,7 @@
                 "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
                 "width": 640,
                 "height": 640
-            }
-        },
+            },
         "comments": {
             "data": [{
                 "created_time": "1279332030",
@@ -91,7 +112,17 @@
             }],
             "count": 2
         },
-        "caption": "some caption",
+        "caption": {
+            "created_time": "1296710352",
+            "text": "Inside le truc #foodtruck",
+            "from": {
+                "username": "kevin",
+                "full_name": "Kevin Systrom",
+                "type": "user",
+                "id": "3"
+            },
+            "id": "26621408"
+        },
         "likes": {
             "count": 1,
             "data": [{
@@ -131,11 +162,12 @@
             "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
             "id": "3"
         },
-        "location": {
-            "id": "id",
-            "latitude": -34,
-            "longitude": -53,
-            "name": "some place"
-        }
-    }]
+            "location": {
+                "id": "833",
+                "latitude": 37.77956816727314,
+                "longitude": -122.41387367248539,
+                "street_address": "",
+                "name": "Civic Center BART"
+            }
+    }}]
 }

--- a/src/source/TCK/RAML10/Instagram1.0/examples/media-example.json
+++ b/src/source/TCK/RAML10/Instagram1.0/examples/media-example.json
@@ -30,7 +30,17 @@
             }],
             "count": 2
         },
-        "caption": "some caption",
+        "caption": {
+            "created_time": "1296710352",
+            "text": "Inside le truc #foodtruck",
+            "from": {
+                "username": "kevin",
+                "full_name": "Kevin Systrom",
+                "type": "user",
+                "id": "3"
+            },
+            "id": "26621408"
+        },
         "likes": {
             "count": 1,
             "data": [{

--- a/src/source/TCK/RAML10/Instagram1.0/examples/ok-status-example.json
+++ b/src/source/TCK/RAML10/Instagram1.0/examples/ok-status-example.json
@@ -1,9 +1,6 @@
 {
-    "geo": {
-        "address": {
-            "city": "SEATTLE",
-            "streetAddress": "300 BOYLSTON AVE E"
-        },
-        "age": 20
-    }
+    "meta": {
+        "code": 200
+    },
+    "data": null
 }

--- a/src/source/TCK/RAML10/Instagram1.0/types.raml
+++ b/src/source/TCK/RAML10/Instagram1.0/types.raml
@@ -6,12 +6,14 @@ types:
         id?: string
         name?: string
         latitude?: number
-        longtitude?: number
+        longitude?: number
+        street_address?: string
       example:
         id: "1"
         name: "John"
         latitude: 34.016242
-        longtitude: -95.800781
+        longitude: -95.800781
+        street_address: ""
     Meta:
       type: object
       properties:
@@ -19,9 +21,8 @@ types:
       example:
         code: 200
     Locations:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?: Location[]
       example:
         meta:
@@ -30,7 +31,7 @@ types:
           - id: "1"
             name: "John"
             latitude: 34.016242
-            longtitude: -95.800781
+            longitude: -95.800781
     Counts:
       type: object
       properties:
@@ -86,9 +87,8 @@ types:
           follows: 3
           followed_by: 5
     SubscriptionPost:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?:
           type: object
           properties:
@@ -125,9 +125,8 @@ types:
         callback_url: "url"
         id: "22"
     SubscriptionsGet:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?:
           type: SubscriptionData[]
       example:
@@ -138,9 +137,8 @@ types:
             callback_url: "url"
             id: "22"
     SubscriptionsDelete:
-       type: object
+       type: OkStatus
        properties:
-         meta?: Meta
          data?:
            type: SubscriptionData
        example:
@@ -171,9 +169,8 @@ types:
         media_count: 2
         name: forest
     TagsSearch:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?: SerachTagItem[]
       example:
         meta:
@@ -209,12 +206,9 @@ types:
         created_time?: string
         text?: string
         from?:
-          type: object
+          type: User
           properties:
-            username?: string
-            profile_picture?: string
-            id?: string
-            full_name?: string
+            type?: string
         id?: string
       example:
         created_time: "1382576494"
@@ -225,9 +219,8 @@ types:
             full_name: "John Smith"
         id: "200"
     MediaComment:
-      type: object
+      type: OkStatus
       properties:
-        meta: Meta
         data: Comment[]
       example:
         meta:
@@ -269,9 +262,8 @@ types:
         version: "2.11"
         width: 600
     RelationshipsPost:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?:
           type: object
           properties:
@@ -282,9 +274,8 @@ types:
         data:
           outgoing_status: "none"
     Relationships:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data?:
           type: object
           properties:
@@ -297,9 +288,8 @@ types:
           outgoing_status: "none"
           incoming_status: "requested_by"
     RequestedBy:
-      type: object
+      type: OkStatus
       properties:
-        meta: Meta
         data:
           type: object
           properties:
@@ -341,38 +331,11 @@ types:
     OkStatus:
       type: object
       properties:
-        geo:
-          type: object
-          properties:
-            address:
-              type: object
-              properties:
-                city: string
-                streetAddress: string
-            age: number
+        meta?: Meta
+        data?: any | null
       example:
-        geo:
-          address:
-            city: "SEATTLE"
-            streetAddress: "300 BOYLSTON AVE E"
-          age: 20
-    Caption:
-      type: object
-      properties:
-        created_time?: string
-        text?: string
-        from?:
-          type: object
-          properties:
-            username?: string
-            id?: string
-        id?: string
-      example:
-        created_time: "1382576494"
-        text: "text"
-        from:
-          username: "John"
-          id: "2000"
+        meta:
+          code: 200
     Likes:
       type: object
       properties:
@@ -439,12 +402,7 @@ types:
                     full_name: "John Smith"
                   id: "200"
               count: 1
-            caption:
-              created_time: "1382576494"
-              text: "text"
-              from:
-                username: "John"
-                id: "2000"
+            caption: null
             likes:
               count: 42
               data:
@@ -460,12 +418,12 @@ types:
             link: "link"
             created_time: "1386312776"
             id: "id"
-            location: "location"
+            location: null
     TagsRecentMediaItem:
       type: object
       properties:
         type?: string
-        users_in_photo?: string[]
+        users_in_photo?: UsersInPhoto[]
         filter?: string
         tags?: string[]
         comments?:
@@ -473,14 +431,13 @@ types:
           properties:
             data?: Comment[]
             count?: number
-        caption?:
-          type: Caption
+        caption?: null | Comment
         likes?: Likes
         link?: string
         created_time?: string
         images?: Image
         id?: string
-        location?: string
+        location?: null | Location
       example:
         type: "photo"
         tags:
@@ -518,7 +475,12 @@ types:
         created_time: "1386312776"
 
         id: "id"
-        location: "location"
+        location:
+          latitude: 37.778720183610183
+          longitude: -122.3962783813477
+          id: "520640"
+          street_address: ""
+          name: Le Truc
     UsersInPhoto:
       type: object
       properties:
@@ -556,13 +518,13 @@ types:
               properties:
                 data?: Comment[]
                 count?: number
-            caption: string
+            caption: null | Comment
             likes: Likes
             link: string
             user: User
             created_time: string
             id: string
-            location: string
+            location: Location | null
       example:
         data:
           users_in_photo:
@@ -592,7 +554,15 @@ types:
                   id: "2000"
                   full_name: "John Smith"
                 id: "200"
-          caption: string
+          caption:
+            created_time: "1296710352"
+            text: Inside le truc #foodtruck
+            from:
+              username: kevin
+              full_name: Kevin Systrom
+              type: user
+              id: "3"
+            id: "26621408"
           likes:
             count: 42
             data:
@@ -608,7 +578,7 @@ types:
           link: "link"
           created_time: "1386312776"
           id: "id"
-          location: "location"
+          location: null
           user:
             id: "1"
             username: "John"
@@ -624,7 +594,7 @@ types:
       properties:
         distance: number
         type?: string
-        users_in_photo: object[]
+        users_in_photo: UsersInPhoto[]
         filter: string
         tags: string[]
         comments:
@@ -632,20 +602,14 @@ types:
           properties:
             data?: Comment[]
             count?: number
-        caption: string
+        caption: null | Comment
         likes: Likes
         link: string
         user: User
         created_time: string
         id: string
         images?: Image
-        location:
-          type: object
-          properties:
-            id: string
-            latitude: number
-            longitude: number
-            name: string
+        location: null | Location
       example:
         distance: 50
         users_in_photo:
@@ -675,7 +639,7 @@ types:
                 id: "2000"
                 full_name: "John Smith"
               id: "200"
-        caption: string
+        caption: null
         likes:
           count: 42
           data:
@@ -734,14 +698,14 @@ types:
               properties:
                 data?: Comment[]
                 count?: number
-            caption: string
+            caption: null | Comment
             likes: Likes
             link: string
             user: User
             created_time: string
             id: string
             images?: Image
-            location: string
+            location: null | Location
       example:
         distance: 50
         videos:
@@ -780,7 +744,15 @@ types:
                   id: "2000"
                   full_name: "John Smith"
                 id: "200"
-          caption: string
+          caption:
+            created_time: "1296710352"
+            text: Inside le truc #foodtruck
+            from:
+              username: kevin
+              full_name: Kevin Systrom
+              type: user
+              id: "3"
+            id: "26621408"
           likes:
             count: 42
             data:
@@ -796,7 +768,12 @@ types:
           link: "link"
           created_time: "1386312776"
           id: "id"
-          location: "location"
+          location:
+            latitude: 37.778720183610183
+            longitude: -122.3962783813477
+            id: "520640"
+            street_address: ""
+            name: "Le Truc"
           user:
             id: "1"
             username: "John"
@@ -808,12 +785,10 @@ types:
               follows: 3
               followed_by: 5
     MediaSearch:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data: MediaSearchFirstType | MediaSearchSecondType
     MediaSearchArray:
-      type: object
+      type: OkStatus
       properties:
-        meta?: Meta
         data: (MediaSearchFirstType | MediaSearchSecondType)[]


### PR DESCRIPTION
Changes:
- the `OkStatus` type is changed in order to be able of describing examples provided by the Instagram reference
- All types having `meta` and `data` fields are given `OkStatus` as supertype
- Types of `caption` fields are changed from `string` to `null | Comment`. The `null` option here is left in order to handle pass those examples from the Instagram reference, which have `null` for 'caption'.
- Types of `location` fields are changed from `string` to `null | Location` (if needed). The reason for the `null` option is the same as above.
- All `users_in_photo` fields are given `UsersInPhoto[]` type, rather then `string[]` or `object[]`.
- The JSON examples are fixed according to the type changes above.
