### PR TITLE
Evaluate error status disregarding error count

### DIFF
--- a/src/source/parsers/javaparser/test-project/src/org/raml/java/parser/tck/test/Main.java
+++ b/src/source/parsers/javaparser/test-project/src/org/raml/java/parser/tck/test/Main.java
@@ -50,7 +50,7 @@ public class Main {
 
 					JSONArray tckErrors = (JSONArray) tckJson.get("errors");
 					
-					if(errors.size() != tckErrors.size()) {
+					if(errors.size() != tckErrors.size() && (errors.size() == 0 || tckErrors.size() == 0)) {
 						System.out.println("java parser failed: " + apiPath);
 						System.out.println("\texpected:" + ( tckErrors.isEmpty() ? " no errors" : ""));
 						


### PR DESCRIPTION
As TCK tests should be minimal and contain at most a single error there's no need to compare the error count
