### PR TITLE
Upadte to 0.2.29

### DIFF
--- a/src/source/TCK/RAML08/MediaTypes/test002/api-tck.json
+++ b/src/source/TCK/RAML08/MediaTypes/test002/api-tck.json
@@ -9,8 +9,8 @@
         "methods": [
           {
             "responses": {
-              "2xx": {
-                "code": "2xx",
+              "200": {
+                "code": "200",
                 "body": {
                   "application/x-www-form-urlencoded": {
                     "name": "application/x-www-form-urlencoded"

--- a/src/source/TCK/RAML08/MediaTypes/test002/api.raml
+++ b/src/source/TCK/RAML08/MediaTypes/test002/api.raml
@@ -6,6 +6,6 @@ title: Test Api
       application/x-www-form-urlencoded:
 
     responses:
-      2xx:
+      200:
         body:
           application/x-www-form-urlencoded:

--- a/src/source/TCK/RAML10/Annotations/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test001/apiInvalid-tck.json
@@ -19,7 +19,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -28,15 +27,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,7 +45,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "W",
@@ -60,9 +54,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test001/apiValid-tck.json
@@ -19,7 +19,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -28,15 +27,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,7 +45,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "W",
@@ -60,9 +54,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test002/apiInvalid-tck.json
@@ -19,7 +19,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -28,15 +27,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,7 +45,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "W",
@@ -60,9 +54,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test002/apiValid-tck.json
@@ -19,7 +19,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -28,15 +27,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,7 +45,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "W",
@@ -60,9 +54,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test003/apiInvalid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -27,15 +26,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -49,7 +44,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "W",
@@ -59,9 +53,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -76,9 +67,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test003/apiValid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "q": {
@@ -27,15 +26,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -49,7 +44,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "enum": [
                 "W",
@@ -59,9 +53,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -76,9 +67,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test004/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,7 +70,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -91,15 +78,11 @@
               "type": [
                 "Point"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,9 +97,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test004/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,7 +70,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -91,15 +78,11 @@
               "type": [
                 "Point"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,9 +97,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test005/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,7 +70,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -91,15 +78,11 @@
               "type": [
                 "Point"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,9 +97,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test005/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,7 +70,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -91,15 +78,11 @@
               "type": [
                 "Point"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,9 +97,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test006/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test006/apiInvalid-tck.json
@@ -7,11 +7,9 @@
         "Point": {
           "name": "Point",
           "displayName": "Point",
-          "additionalProperties": false,
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -20,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -59,13 +49,11 @@
               }
             }
           },
+          "additionalProperties": false,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -92,15 +79,11 @@
               "type": [
                 "Point[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -115,9 +98,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test006/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test006/apiValid-tck.json
@@ -7,11 +7,9 @@
         "Point": {
           "name": "Point",
           "displayName": "Point",
-          "additionalProperties": false,
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -20,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -59,13 +49,11 @@
               }
             }
           },
+          "additionalProperties": false,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -92,15 +79,11 @@
               "type": [
                 "Point[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -115,9 +98,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test006/apiValid1-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test006/apiValid1-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,7 +70,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "point": {
@@ -91,15 +78,11 @@
               "type": [
                 "Point[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,9 +97,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test007/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test007/apiInvalid-tck.json
@@ -21,7 +21,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "v": {
@@ -30,15 +29,11 @@
               "type": [
                 "boolean[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -53,9 +48,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test007/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test007/apiValid-tck.json
@@ -21,7 +21,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "v": {
@@ -30,15 +29,11 @@
               "type": [
                 "boolean[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -53,9 +48,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test008/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test008/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test008/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test008/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test009/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test009/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test009/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test009/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test010/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test010/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test010/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test010/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test011/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test011/apiInvalid-tck.json
@@ -24,7 +24,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -33,15 +32,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -59,9 +54,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -76,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -85,15 +76,11 @@
               "type": [
                 "Pet"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -108,9 +95,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -127,7 +111,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -136,15 +119,11 @@
               "type": [
                 "Person"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -159,9 +138,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -180,7 +156,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "persons": {
@@ -189,15 +164,11 @@
               "type": [
                 "MapOfPerson"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -212,9 +183,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test011/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test011/apiValid-tck.json
@@ -24,7 +24,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -33,15 +32,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -59,9 +54,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -76,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -85,15 +76,11 @@
               "type": [
                 "Pet"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -108,9 +95,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -127,7 +111,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -136,15 +119,11 @@
               "type": [
                 "Person"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -159,9 +138,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -180,7 +156,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "persons": {
@@ -189,15 +164,11 @@
               "type": [
                 "MapOfPerson"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -212,9 +183,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test012/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test012/apiInvalid-tck.json
@@ -20,7 +20,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -29,7 +28,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "/.*/": {
@@ -38,15 +36,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -63,9 +57,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -79,9 +70,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test012/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test012/apiValid-tck.json
@@ -20,7 +20,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -29,7 +28,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "/.*/": {
@@ -38,15 +36,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -63,9 +57,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -79,9 +70,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test013/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test013/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -37,7 +33,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "level": {
@@ -46,7 +41,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "low",
@@ -61,9 +55,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -76,15 +67,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -99,9 +86,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test013/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test013/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -37,7 +33,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "level": {
@@ -46,7 +41,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "low",
@@ -61,9 +55,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -76,15 +67,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -99,9 +86,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Annotations/test014/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test014/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -63,7 +55,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "Metadata for this resource",
           "allowedTargets": [
@@ -71,9 +62,6 @@
           ],
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test014/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test014/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -63,7 +55,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "Metadata for this resource",
           "allowedTargets": [
@@ -71,9 +62,6 @@
           ],
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -63,7 +55,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "Metadata for this resource",
           "allowedTargets": [
@@ -72,9 +63,6 @@
           "minLength": 10,
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test015/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test015/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -63,7 +55,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "Metadata for this resource",
           "allowedTargets": [
@@ -72,9 +63,6 @@
           "minLength": 10,
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test016/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test016/apiInvalid-tck.json
@@ -16,7 +16,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -31,15 +30,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -52,9 +47,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -72,7 +64,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "Resource",
@@ -84,9 +75,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -103,7 +91,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "TypeDeclaration"
@@ -112,9 +99,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -162,15 +146,11 @@
                     "type": [
                       "User[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test016/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test016/apiValid-tck.json
@@ -16,7 +16,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -31,15 +30,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -52,9 +47,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -72,7 +64,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "Resource",
@@ -84,9 +75,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -103,7 +91,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "TypeDeclaration"
@@ -112,9 +99,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -158,15 +142,11 @@
                     "type": [
                       "User[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test017/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test017/apiInvalid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "numberProp": {
@@ -27,15 +26,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -69,7 +61,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "stringParam": {
@@ -78,15 +69,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -101,9 +88,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -124,7 +108,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -132,9 +115,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -156,7 +136,6 @@
           "type": [
             "MyType"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "TypeDeclaration"
@@ -165,9 +144,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test017/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test017/apiValid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "numberProp": {
@@ -27,15 +26,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -69,7 +61,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "stringParam": {
@@ -78,15 +69,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -101,9 +88,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -124,7 +108,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -132,9 +115,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -156,7 +136,6 @@
           "type": [
             "MyType"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "API"
@@ -165,9 +144,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test018/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test018/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -36,15 +32,11 @@
           "type": [
             "amazon-apigateway-integration1"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test018/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test018/apiValid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -36,15 +32,11 @@
           "type": [
             "amazon-apigateway-integration"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test019/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test019/apiInvalid-tck.json
@@ -16,15 +16,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -42,15 +38,11 @@
           "type": [
             "amazon-apigateway-integration"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test019/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test019/apiValid-tck.json
@@ -16,15 +16,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -42,15 +38,11 @@
           "type": [
             "amazon-apigateway-integration"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test020/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test020/apiInvalid-tck.json
@@ -12,7 +12,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -20,9 +19,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -45,15 +41,11 @@
           "type": [
             "null"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,7 +61,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "default": {
@@ -78,7 +69,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "low",
@@ -92,9 +82,6 @@
                   },
                   "type": {
                     "insertedAsDefault": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -106,9 +93,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -149,7 +133,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -157,9 +140,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -179,7 +159,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -187,9 +166,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Annotations/test020/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test020/apiValid-tck.json
@@ -12,7 +12,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -20,9 +19,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -45,15 +41,11 @@
           "type": [
             "null"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,7 +61,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "default": {
@@ -78,7 +69,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "low",
@@ -92,9 +82,6 @@
                   },
                   "type": {
                     "insertedAsDefault": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -106,9 +93,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -143,7 +127,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -151,9 +134,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -173,7 +153,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -181,9 +160,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Annotations/test021/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test021/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "allowedTargets": [
             "SecuritySchemeSettings"
@@ -19,9 +18,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test021/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test021/apiValid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test022/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test022/apiInvalid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "numberProp": {
@@ -27,15 +26,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -71,15 +63,11 @@
           "type": [
             "MyType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test022/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test022/apiValid-tck.json
@@ -18,7 +18,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "numberProp": {
@@ -27,15 +26,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -71,15 +63,11 @@
           "type": [
             "MyType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test023/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test023/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test023/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test023/apiValid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test024/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test024/apiInvalid-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "minimum": 2,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test024/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test024/apiValid-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "minimum": 2,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test025/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test025/apiInvalid-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "maximum": 10,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test025/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test025/apiValid-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "maximum": 10,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test026/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test026/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "boolean"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test026/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test026/apiValid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test027/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test027/api-tck.json
@@ -26,7 +26,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -34,9 +33,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -55,7 +51,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "pattern": "[a-zA-Z0-9]{8,32}",
           "minLength": 8,
@@ -66,9 +61,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -85,7 +77,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -94,7 +85,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "field1": {
@@ -103,7 +93,6 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
@@ -111,9 +100,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -128,15 +114,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -153,9 +135,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -168,7 +147,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -176,9 +154,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -194,9 +169,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -217,7 +189,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -229,9 +200,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Annotations/test028/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test028/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "baseProperty1": {
@@ -19,7 +18,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "field1": {
@@ -28,7 +26,6 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
@@ -36,9 +33,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -53,15 +47,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -78,9 +68,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -93,7 +80,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -101,9 +87,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -119,9 +102,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -152,7 +132,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -160,9 +139,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -181,7 +157,6 @@
           "type": [
             "baseAnnotation"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "childProperty1": {
@@ -191,7 +166,6 @@
                 "string"
               ],
               "default": "enum_defaultValue",
-              "repeat": false,
               "required": true,
               "enum": [
                 "enum_defaultValue",
@@ -204,9 +178,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -222,15 +193,11 @@
                 "number"
               ],
               "default": 22,
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -243,9 +210,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -265,7 +229,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -277,9 +240,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Annotations/test029/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test029/api-tck.json
@@ -36,7 +36,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "pattern": "[a-zA-Z0-9]{8,32}",
           "minLength": 8,
@@ -47,9 +46,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -66,7 +62,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -75,7 +70,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "field1": {
@@ -84,7 +78,6 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
@@ -92,9 +85,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -109,15 +99,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -134,9 +120,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -149,7 +132,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -157,9 +139,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -175,9 +154,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -198,7 +174,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -210,9 +185,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Annotations/test030/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test030/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "array"
           ],
-          "repeat": false,
           "required": true,
           "items": {
             "name": "items",
@@ -18,7 +17,6 @@
             "type": [
               "object"
             ],
-            "repeat": false,
             "required": true,
             "properties": {
               "cardId": {
@@ -44,16 +42,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": false,
                 "description": "Card identifier.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -67,9 +61,6 @@
                 "type": {
                   "insertedAsDefault": true
                 },
-                "repeat": {
-                  "insertedAsDefault": true
-                },
                 "required": {
                   "insertedAsDefault": true
                 }
@@ -80,9 +71,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -100,7 +88,6 @@
           "type": [
             "array"
           ],
-          "repeat": false,
           "required": true,
           "items": {
             "name": "items",
@@ -108,7 +95,6 @@
             "type": [
               "object"
             ],
-            "repeat": false,
             "required": true,
             "properties": {
               "method": {
@@ -117,7 +103,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "This field defines to which method the binding applies",
                 "enum": [
@@ -131,9 +116,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -144,7 +126,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "The binding related to the field when used as an input",
                 "enum": [
@@ -156,9 +137,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -169,7 +147,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "The binding related to the field when used as an output",
                 "enum": [
@@ -181,9 +158,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -197,9 +171,6 @@
                 "type": {
                   "insertedAsDefault": true
                 },
-                "repeat": {
-                  "insertedAsDefault": true
-                },
                 "required": {
                   "insertedAsDefault": true
                 }
@@ -208,9 +179,6 @@
           },
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test031/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test031/api-tck.json
@@ -16,7 +16,6 @@
           "type": [
             "array"
           ],
-          "repeat": false,
           "required": true,
           "items": {
             "name": "items",
@@ -24,7 +23,6 @@
             "type": [
               "object"
             ],
-            "repeat": false,
             "required": true,
             "properties": {
               "cardId": {
@@ -50,16 +48,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": false,
                 "description": "Card identifier.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -73,9 +67,6 @@
                 "type": {
                   "insertedAsDefault": true
                 },
-                "repeat": {
-                  "insertedAsDefault": true
-                },
                 "required": {
                   "insertedAsDefault": true
                 }
@@ -86,9 +77,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Annotations/test032/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test032/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "array"
           ],
-          "repeat": false,
           "required": true,
           "items": {
             "name": "items",
@@ -18,7 +17,6 @@
             "type": [
               "object"
             ],
-            "repeat": false,
             "required": true,
             "properties": {
               "method": {
@@ -27,7 +25,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "This field defines to which method the binding applies",
                 "enum": [
@@ -41,9 +38,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -54,7 +48,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "The binding related to the field when used as an input",
                 "enum": [
@@ -66,9 +59,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -79,7 +69,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "The binding related to the field when used as an output",
                 "enum": [
@@ -91,9 +80,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -107,9 +93,6 @@
                 "type": {
                   "insertedAsDefault": true
                 },
-                "repeat": {
-                  "insertedAsDefault": true
-                },
                 "required": {
                   "insertedAsDefault": true
                 }
@@ -118,9 +101,6 @@
           },
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Annotations/test034/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test034/api-tck.json
@@ -26,7 +26,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -34,9 +33,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -55,7 +51,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "pattern": "[a-zA-Z0-9]{8,32}",
           "minLength": 8,
@@ -66,9 +61,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -85,7 +77,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -94,7 +85,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "field1": {
@@ -103,7 +93,6 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
@@ -111,9 +100,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -128,15 +114,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -153,9 +135,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -168,7 +147,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -176,9 +154,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -194,9 +169,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -217,7 +189,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -229,9 +200,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Annotations/test035/api-tck.json
+++ b/src/source/TCK/RAML10/Annotations/test035/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "null"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Api/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test005/api-tck.json
@@ -13,7 +13,6 @@
         ],
         "default": "test.com",
         "example": "example.com",
-        "repeat": false,
         "required": true,
         "description": "Api base uri parameter domain",
         "enum": [
@@ -27,9 +26,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -50,7 +46,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "calculated": true,
@@ -59,9 +54,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test006/api-tck.json
@@ -11,7 +11,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "calculated": true,
@@ -20,9 +19,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test007/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test007/api-tck.json
@@ -10,7 +10,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "calculated": true,
@@ -19,9 +18,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test008/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test008/api-tck.json
@@ -12,7 +12,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "2"
@@ -24,9 +23,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test016/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test016/api-tck.json
@@ -12,14 +12,10 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "This is A",
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -32,14 +28,10 @@
           "type": [
             "integer"
           ],
-          "repeat": false,
           "required": true,
           "description": "This is A",
           "__METADATA__": {
             "primitiveValuesMeta": {
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }

--- a/src/source/TCK/RAML10/Api/test017/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test017/api-tck.json
@@ -11,7 +11,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "calculated": true,
@@ -20,9 +19,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -37,14 +33,10 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test018/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test018/api-tck.json
@@ -11,15 +11,11 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test019/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test019/api-tck.json
@@ -11,7 +11,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "minLength": 123,
@@ -23,9 +22,6 @@
         "__METADATA__": {
           "primitiveValuesMeta": {
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Api/test020/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test020/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "X"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test021/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test021/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test022/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test022/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "number"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test023/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test023/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "integer"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test024/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test024/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "datetime"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test025/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test025/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "file"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Api/test026/api-tck.json
+++ b/src/source/TCK/RAML10/Api/test026/api-tck.json
@@ -11,14 +11,10 @@
         "type": [
           "boolean"
         ],
-        "repeat": false,
         "required": true,
         "description": "This is A",
         "__METADATA__": {
           "primitiveValuesMeta": {
-            "repeat": {
-              "insertedAsDefault": true
-            },
             "required": {
               "insertedAsDefault": true
             }

--- a/src/source/TCK/RAML10/Examples/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test001/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "a": 5
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -22,15 +21,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,9 +40,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -82,7 +74,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "x": {
@@ -91,15 +82,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -114,9 +101,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test002/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test002/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -37,7 +33,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "firstName": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -68,15 +59,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -91,9 +78,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -124,7 +108,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -133,15 +116,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -155,15 +134,11 @@
               "type": [
                 "URL"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -177,15 +152,11 @@
               "type": [
                 "User[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -199,15 +170,11 @@
               "type": [
                 "any"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -222,9 +189,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test003/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test003/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -37,7 +33,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "firstName": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -68,15 +59,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -91,9 +78,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -125,7 +109,6 @@
             ],
             "X": "x"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -134,15 +117,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -156,15 +135,11 @@
               "type": [
                 "URL"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -178,15 +153,11 @@
               "type": [
                 "User[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -200,15 +171,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -223,9 +190,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test004/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test004/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -37,7 +33,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "firstName": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -68,15 +59,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -91,9 +78,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -125,7 +109,6 @@
             ],
             "X": "x"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -134,15 +117,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -156,15 +135,11 @@
               "type": [
                 "URL"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -178,15 +153,11 @@
               "type": [
                 "User[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -200,15 +171,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -223,9 +190,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test005/api-tck.json
@@ -14,7 +14,6 @@
             "c": "A",
             "y": 3
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,15 +40,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -66,9 +57,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test006/api-tck.json
@@ -15,7 +15,6 @@
             "y": 3,
             "z": 5
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -24,15 +23,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -46,15 +41,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -69,9 +60,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test007/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test007/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "y": "aaa2"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "y": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "val1",
@@ -33,9 +31,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test008/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test008/api-tck.json
@@ -28,7 +28,6 @@
               1
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "items": {
@@ -37,16 +36,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "minItems": 5,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -60,16 +55,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "maxItems": 3,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -83,16 +74,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "uniqueItems": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -107,9 +94,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test009/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test009/api-tck.json
@@ -27,7 +27,6 @@
               3
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "items": {
@@ -36,16 +35,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "minItems": 3,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -59,16 +54,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "maxItems": 3,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -82,16 +73,12 @@
               "type": [
                 "number[]"
               ],
-              "repeat": false,
               "required": true,
               "uniqueItems": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -106,9 +93,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test010/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test010/api-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string[]"
           ],
-          "repeat": false,
           "required": true,
           "minItems": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -42,7 +38,6 @@
               "3"
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "items": {
@@ -51,15 +46,11 @@
               "type": [
                 "SmallArray"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -74,9 +65,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test011/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test011/api-tck.json
@@ -27,16 +27,12 @@
           "type": [
             "number[]"
           ],
-          "repeat": false,
           "required": true,
           "minItems": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -54,7 +50,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "cc": {
@@ -63,15 +58,11 @@
               "type": [
                 "SmallArray"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +79,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -105,7 +93,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -113,9 +100,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test012/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test012/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -75,7 +67,6 @@
                       "message": "s",
                       "r": 2
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -83,9 +74,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test013/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test013/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "d": "a"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,9 +40,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test014/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test014/api-tck.json
@@ -14,7 +14,6 @@
             "d": "a",
             "dd": "2"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -47,9 +42,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -78,15 +70,11 @@
           "example": {
             "x": "3"
           },
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test015/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test015/api-tck.json
@@ -14,7 +14,6 @@
             "d": "a",
             "dd": "2"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -47,9 +42,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -78,15 +70,11 @@
           "example": {
             "x": "3"
           },
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test016/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test016/api-tck.json
@@ -21,7 +21,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -30,15 +29,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -54,9 +49,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -75,7 +67,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "pp": {
@@ -84,15 +75,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -107,9 +94,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test017/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test017/api-tck.json
@@ -21,7 +21,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -30,15 +29,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -54,9 +49,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -75,7 +67,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "pp": {
@@ -84,15 +75,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -107,9 +94,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test018/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test018/api-tck.json
@@ -11,7 +11,6 @@
             "string"
           ],
           "example": "d",
-          "repeat": false,
           "required": true,
           "minLength": 5,
           "__METADATA__": {
@@ -20,9 +19,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -46,7 +42,6 @@
             "string"
           ],
           "example": "d1111",
-          "repeat": false,
           "required": true,
           "maxLength": 3,
           "__METADATA__": {
@@ -55,9 +50,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test019/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test019/api-tck.json
@@ -11,7 +11,6 @@
             "string"
           ],
           "example": "ddddd",
-          "repeat": false,
           "required": true,
           "minLength": 5,
           "__METADATA__": {
@@ -20,9 +19,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -46,7 +42,6 @@
             "string"
           ],
           "example": "111",
-          "repeat": false,
           "required": true,
           "maxLength": 3,
           "__METADATA__": {
@@ -55,9 +50,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test020/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test020/api-tck.json
@@ -11,7 +11,6 @@
             "string"
           ],
           "example": "ddddd",
-          "repeat": false,
           "required": true,
           "minLength": 5,
           "__METADATA__": {
@@ -20,9 +19,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -48,7 +44,6 @@
           "example": {
             "z": "3"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -57,15 +52,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -80,9 +71,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test021/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test021/api-tck.json
@@ -11,7 +11,6 @@
             "string"
           ],
           "example": "d5",
-          "repeat": false,
           "required": true,
           "pattern": ".5",
           "__METADATA__": {
@@ -20,9 +19,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -48,7 +44,6 @@
           "example": {
             "z": ".3"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -57,15 +52,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -80,9 +71,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test022/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test022/api-tck.json
@@ -11,16 +11,12 @@
             "number"
           ],
           "example": 4,
-          "repeat": false,
           "required": true,
           "minimum": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -45,7 +41,6 @@
           "example": {
             "z": 3
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -54,15 +49,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test023/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test023/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "a": 5
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -22,15 +21,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,9 +40,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -86,7 +78,6 @@
                       "message": 4,
                       "vlue": 3
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -94,9 +85,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test024/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test024/api-tck.json
@@ -11,16 +11,12 @@
             "number"
           ],
           "example": 5,
-          "repeat": false,
           "required": true,
           "minimum": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -45,7 +41,6 @@
           "example": {
             "z": 5
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -54,15 +49,11 @@
               "type": [
                 "MyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test025/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test025/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -80,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -89,15 +76,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -111,7 +94,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": false,
               "properties": {
                 "mimeType": {
@@ -120,15 +102,11 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -142,15 +120,11 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -164,15 +138,11 @@
                   "type": [
                     "Header[]"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -186,7 +156,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": false,
                   "properties": {
                     "size": {
@@ -195,15 +164,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": false,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -217,15 +182,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": false,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -239,9 +200,6 @@
                       "displayName": {
                         "calculated": true
                       },
-                      "repeat": {
-                        "insertedAsDefault": true
-                      },
                       "required": {
                         "insertedAsDefault": true
                       }
@@ -254,15 +212,11 @@
                   "type": [
                     "Message[]"
                   ],
-                  "repeat": false,
                   "required": false,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -275,9 +229,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -291,15 +242,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -312,9 +259,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -366,7 +310,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -375,15 +318,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -397,15 +336,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -419,15 +354,11 @@
               "type": [
                 "Message[]"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -440,9 +371,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test026/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test026/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -63,15 +54,11 @@
               "type": [
                 "TestType4"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -105,7 +89,6 @@
           "type": [
             "TestType"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name4": {
@@ -114,15 +97,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -135,9 +114,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -153,7 +129,6 @@
           "type": [
             "TestType2"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name5": {
@@ -162,15 +137,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -183,9 +154,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -201,7 +169,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "proppp": {
@@ -210,15 +177,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -231,9 +194,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -253,7 +213,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -265,9 +224,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -298,15 +254,11 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -322,15 +274,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -349,7 +297,6 @@
                         "schema": [
                           "{\"required\": true,\"$schema\": \"http://json-schema.org/draft-03/schema\",\"type\": \"object\",\"properties\": {  \"message\": {\"required\": false,\"type\": \"string\"}}}"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
@@ -357,9 +304,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -379,7 +323,6 @@
                         "schema": [
                           "{\n  \"required\": true,\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"message\": {\n      \"required\": false,\n      \"type\": \"string\"\n    }\n  }\n}\n"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
@@ -387,9 +330,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -409,15 +349,11 @@
                         "type": [
                           "TestType"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test027/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test027/api-tck.json
@@ -14,7 +14,6 @@
             "name": "stringValue",
             "age": 0
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,15 +40,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -68,9 +59,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test028/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test028/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "x": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -74,7 +66,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "hello": {
@@ -83,7 +74,6 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "minimum": 0,
                         "maximum": 10,
@@ -95,9 +85,6 @@
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -114,7 +101,6 @@
                         "example": {
                           "x2": 123
                         },
-                        "repeat": false,
                         "required": true,
                         "properties": {
                           "x": {
@@ -123,15 +109,11 @@
                             "type": [
                               "string"
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -144,9 +126,6 @@
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -168,9 +147,6 @@
                         "displayName": {
                           "calculated": true
                         },
-                        "repeat": {
-                          "insertedAsDefault": true
-                        },
                         "required": {
                           "insertedAsDefault": true
                         }
@@ -183,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test029/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test029/api-tck.json
@@ -11,7 +11,6 @@
             "string"
           ],
           "example": "POST",
-          "repeat": false,
           "required": true,
           "enum": [
             "GET",
@@ -25,9 +24,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -49,7 +45,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "pattern": "^[12345]\\d\\d$",
           "__METADATA__": {
@@ -58,9 +53,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -77,7 +69,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "/\\w+/\\w+/": {
@@ -86,7 +77,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -94,9 +84,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -112,9 +99,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -131,7 +115,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "enum": [
             "aws_iam"
@@ -142,9 +125,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -161,7 +141,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -170,7 +149,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "lambda"
@@ -181,9 +159,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -199,9 +174,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,7 +190,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -227,7 +198,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "HTTP"
@@ -238,9 +208,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -256,9 +223,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -275,7 +239,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -284,7 +247,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "mock"
@@ -295,9 +257,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -313,9 +272,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -370,7 +326,6 @@
               }
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -379,7 +334,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "aws"
@@ -390,9 +344,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -407,7 +358,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -415,9 +365,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -432,15 +379,11 @@
               "type": [
                 "amazon-apigateway-method"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -454,7 +397,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -462,9 +404,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -479,15 +418,11 @@
               "type": [
                 "amazon-apigateway-templates"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -501,15 +436,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -523,7 +454,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -531,9 +461,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -548,15 +475,11 @@
               "type": [
                 "string[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -570,7 +493,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "/.*/": {
@@ -579,7 +501,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "statusCode": {
@@ -588,15 +509,11 @@
                       "type": [
                         "amazon-apigateway-status"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -610,15 +527,11 @@
                       "type": [
                         "object"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -632,15 +545,11 @@
                       "type": [
                         "amazon-apigateway-templates"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -655,9 +564,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -675,9 +581,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -691,9 +594,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test030/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test030/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "enum": [
             "aws_iam"
@@ -21,9 +20,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -40,7 +36,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -49,7 +44,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "lambda"
@@ -60,9 +54,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -78,9 +69,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -97,7 +85,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -106,7 +93,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "HTTP"
@@ -117,9 +103,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -135,9 +118,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -154,7 +134,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -163,7 +142,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "mock"
@@ -174,9 +152,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -192,9 +167,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -211,7 +183,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -220,7 +191,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "aws"
@@ -231,9 +201,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -251,9 +218,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -268,15 +232,11 @@
           "type": [
             "amazon-apigateway-integration-lambda | amazon-apigateway-integration-HTTP | amazon-apigateway-integration-mock | amazon-apigateway-integration-aws"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -294,7 +254,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "value": {
@@ -303,15 +262,11 @@
               "type": [
                 "amazon-apigateway-auth-type"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -326,9 +281,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -345,7 +297,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "value": {
@@ -354,15 +305,11 @@
               "type": [
                 "amazon-apigateway-integration"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -377,9 +324,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -403,7 +347,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -411,9 +354,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Examples/test031/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test031/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,7 +30,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -43,7 +38,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "a",
@@ -54,9 +48,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -69,9 +60,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test032/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test032/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "baseField": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "TypeBase"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -67,15 +58,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -127,7 +111,6 @@
                         }
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "additionalField": {
@@ -136,15 +119,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -157,9 +136,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test033/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test033/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "baseField": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "TypeBase"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -67,15 +58,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -120,7 +104,6 @@
                       "baseField": "asdasd",
                       "field": "asdds"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "additionalField": {
@@ -129,15 +112,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -150,9 +129,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test034/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test034/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -63,15 +54,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -84,9 +71,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -104,7 +88,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -113,15 +96,11 @@
               "type": [
                 "MM"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -136,9 +115,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -168,7 +144,6 @@
                     "example": {
                       "a": 3
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -176,9 +151,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test035/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test035/api-tck.json
@@ -16,7 +16,6 @@
               "someProperty": "stringValue2"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -25,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -48,9 +43,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test036/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test036/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "prop1": "stringValue"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/.*/": {
@@ -22,15 +21,11 @@
               "type": [
                 "string[] | string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,9 +40,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test037/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test037/api-tck.json
@@ -11,15 +11,11 @@
             "number"
           ],
           "example": 100,
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -45,15 +41,11 @@
             100,
             10
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -79,15 +71,11 @@
             "boolean"
           ],
           "example": true,
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test038/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test038/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "hello": {
@@ -19,7 +18,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "FOO",
@@ -32,9 +30,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -50,9 +45,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -77,7 +69,6 @@
                 ],
                 "default": "FOO",
                 "example": "FOO",
-                "repeat": false,
                 "required": true,
                 "enum": [
                   "FOO",
@@ -90,9 +81,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Examples/test039/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test039/api-tck.json
@@ -15,7 +15,6 @@
                   "number"
                 ],
                 "example": 2,
-                "repeat": true,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {

--- a/src/source/TCK/RAML10/Examples/test039/api.raml
+++ b/src/source/TCK/RAML10/Examples/test039/api.raml
@@ -6,5 +6,4 @@ title: Test API
     queryParameters:
       param1:
         type: number
-        repeat: true
         example: 2

--- a/src/source/TCK/RAML10/Examples/test040/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test040/api-tck.json
@@ -17,7 +17,6 @@
                 "example": [
                   2
                 ],
-                "repeat": true,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -62,19 +61,19 @@
       "code": 11,
       "message": "number is expected",
       "path": "api.raml",
-      "line": 9,
-      "column": 19,
-      "position": 142,
+      "line": 8,
+      "column": 8,
+      "position": 110,
       "range": [
         {
-          "line": 9,
-          "column": 19,
-          "position": 142
+          "line": 8,
+          "column": 8,
+          "position": 110
         },
         {
-          "line": 9,
-          "column": 20,
-          "position": 143
+          "line": 8,
+          "column": 15,
+          "position": 117
         }
       ]
     }

--- a/src/source/TCK/RAML10/Examples/test040/api.raml
+++ b/src/source/TCK/RAML10/Examples/test040/api.raml
@@ -6,5 +6,4 @@ title: Test API
     queryParameters:
       param1:
         type: number
-        repeat: true
         example: [ 2 ]

--- a/src/source/TCK/RAML10/Examples/test041/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test041/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -80,7 +68,6 @@
           "type": [
             "MM"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -89,15 +76,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -110,9 +93,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -130,7 +110,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -139,15 +118,11 @@
               "type": [
                 "MM"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -162,9 +137,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -194,7 +166,6 @@
                     "example": {
                       "a": 3
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -202,9 +173,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test042/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test042/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "VV[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -80,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -89,15 +76,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -111,7 +94,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -119,9 +101,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -136,7 +115,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -144,9 +122,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -160,9 +135,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -180,7 +152,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -189,15 +160,11 @@
               "type": [
                 "MM"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -212,9 +179,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -253,7 +217,6 @@
                         }
                       ]
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -261,9 +224,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Examples/test043/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test043/api-tck.json
@@ -29,7 +29,6 @@
               }
             }
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "a": {
@@ -38,15 +37,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -60,15 +55,11 @@
               "type": [
                 "VV[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -81,9 +72,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -99,7 +87,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "r2": {
@@ -108,7 +95,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -116,9 +102,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -133,15 +116,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -155,7 +134,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -163,9 +141,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -179,9 +154,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -199,7 +171,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "z": {
@@ -208,15 +179,11 @@
               "type": [
                 "MM"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -231,9 +198,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test044/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test044/api-tck.json
@@ -15,15 +15,11 @@
                   "boolean"
                 ],
                 "example": true,
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -44,15 +40,11 @@
                   "boolean"
                 ],
                 "example": "stringValue",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test045/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test045/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "pattern": "^\\d+\\-\\w+$",
           "__METADATA__": {
@@ -19,9 +18,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -54,15 +50,11 @@
                   ]
                 }
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test046/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test046/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "prop1": "value1"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -30,9 +28,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,9 +43,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test047/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test047/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "prop1": "value1"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -30,9 +28,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,9 +43,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test048/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test048/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "prop1": "value1"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -30,9 +28,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,9 +43,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test049/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test049/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "prop1": "value1"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -30,9 +28,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,9 +43,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -91,15 +83,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -115,15 +103,11 @@
           "type": [
             "ObjectType1"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test050/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test050/api-tck.json
@@ -56,7 +56,6 @@
               }
             }
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -65,7 +64,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -73,9 +71,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -91,9 +86,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,15 +104,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -136,15 +124,11 @@
           "type": [
             "ObjectType1"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test051/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test051/api-tck.json
@@ -56,7 +56,6 @@
               }
             }
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "prop1": {
@@ -65,7 +64,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -73,9 +71,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -91,9 +86,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,15 +104,11 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -136,15 +124,11 @@
           "type": [
             "ObjectType1"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test052/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test052/api-tck.json
@@ -61,15 +61,11 @@
                         "pic": "http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png"
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test053/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test053/lib-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "Fred"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,7 +21,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -30,9 +28,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -47,7 +42,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -55,9 +49,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -71,9 +62,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test054/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test054/lib-tck.json
@@ -14,7 +14,6 @@
             "name": "Fred",
             "comment": ""
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,7 +22,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -31,9 +29,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,7 +43,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -56,9 +50,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -72,9 +63,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test055/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test055/lib-tck.json
@@ -14,7 +14,6 @@
             "name": "Fred",
             "size": 0
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,7 +22,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -31,9 +29,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,15 +43,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -69,9 +60,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test056/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test056/lib-tck.json
@@ -14,7 +14,6 @@
             "name": null,
             "data": null
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,7 +22,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -31,9 +29,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -48,15 +43,11 @@
               "type": [
                 "Data"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -71,9 +62,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -99,7 +87,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -108,7 +95,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -116,9 +102,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -133,7 +116,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -141,9 +123,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -159,9 +138,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test057/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test057/lib-tck.json
@@ -14,7 +14,6 @@
             "name": null,
             "data": null
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,15 +22,11 @@
               "type": [
                 "null | string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,15 +40,11 @@
               "type": [
                 "null | Data"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -68,9 +59,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -96,7 +84,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -105,7 +92,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -113,9 +99,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -130,7 +113,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -138,9 +120,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -156,9 +135,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Examples/test058/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test058/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "Cat | Dog"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,7 +30,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -43,15 +38,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -65,15 +56,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -86,9 +73,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -104,7 +88,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -113,15 +96,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -135,15 +114,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -156,9 +131,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -188,15 +160,11 @@
                       "name": "Rex",
                       "fangs": "big ones"
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -226,7 +194,6 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "calculated": true,
@@ -235,9 +202,6 @@
                   "calculated": true
                 },
                 "type": {
-                  "insertedAsDefault": true
-                },
-                "repeat": {
                   "insertedAsDefault": true
                 },
                 "required": {

--- a/src/source/TCK/RAML10/Examples/test059/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test059/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "Cat | Dog"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,7 +30,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -43,15 +38,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -65,15 +56,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -86,9 +73,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -104,7 +88,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -113,15 +96,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -135,15 +114,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -156,9 +131,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -188,15 +160,11 @@
                       "name": "Rex",
                       "fangs-INCORRECT": "big ones"
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -226,7 +194,6 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "calculated": true,
@@ -235,9 +202,6 @@
                   "calculated": true
                 },
                 "type": {
-                  "insertedAsDefault": true
-                },
-                "repeat": {
                   "insertedAsDefault": true
                 },
                 "required": {

--- a/src/source/TCK/RAML10/Examples/test060/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test060/api-tck.json
@@ -15,15 +15,11 @@
             1,
             2
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -56,7 +52,6 @@
               0
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "p": {
@@ -65,15 +60,11 @@
               "type": [
                 "MyArrayType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +79,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -128,15 +116,11 @@
                     "type": [
                       "MyType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -167,15 +151,11 @@
                     "type": [
                       "MyType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test061/api-tck.json
+++ b/src/source/TCK/RAML10/Examples/test061/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "number[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -41,7 +37,6 @@
               0
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "p": {
@@ -50,15 +45,11 @@
               "type": [
                 "MyArrayType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -73,9 +64,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -113,15 +101,11 @@
                     "type": [
                       "MyType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,15 +136,11 @@
                     "type": [
                       "MyType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test062/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test062/lib-tck.json
@@ -11,15 +11,11 @@
             "boolean"
           ],
           "example": false,
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Examples/test063/lib-tck.json
+++ b/src/source/TCK/RAML10/Examples/test063/lib-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "p1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -95,15 +83,11 @@
                   "p1": "stringValue",
                   "p2": 10
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Fragments/test001/fragment-tck.json
+++ b/src/source/TCK/RAML10/Fragments/test001/fragment-tck.json
@@ -5,7 +5,6 @@
     "type": [
       "object"
     ],
-    "repeat": false,
     "required": true,
     "properties": {
       "prop1": {
@@ -14,15 +13,11 @@
         "type": [
           "number"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "primitiveValuesMeta": {
             "displayName": {
               "calculated": true
-            },
-            "repeat": {
-              "insertedAsDefault": true
             },
             "required": {
               "insertedAsDefault": true
@@ -36,15 +31,11 @@
         "type": [
           "lib.ObjectType"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "primitiveValuesMeta": {
             "displayName": {
               "calculated": true
-            },
-            "repeat": {
-              "insertedAsDefault": true
             },
             "required": {
               "insertedAsDefault": true
@@ -62,9 +53,6 @@
     "__METADATA__": {
       "primitiveValuesMeta": {
         "type": {
-          "insertedAsDefault": true
-        },
-        "repeat": {
           "insertedAsDefault": true
         },
         "required": {

--- a/src/source/TCK/RAML10/Fragments/test004/DataType-tck.json
+++ b/src/source/TCK/RAML10/Fragments/test004/DataType-tck.json
@@ -5,7 +5,6 @@
     "type": [
       "object"
     ],
-    "repeat": false,
     "required": true,
     "properties": {
       "first": {
@@ -14,15 +13,11 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "primitiveValuesMeta": {
             "displayName": {
               "calculated": true
-            },
-            "repeat": {
-              "insertedAsDefault": true
             },
             "required": {
               "insertedAsDefault": true
@@ -36,15 +31,11 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "__METADATA__": {
           "primitiveValuesMeta": {
             "displayName": {
               "calculated": true
-            },
-            "repeat": {
-              "insertedAsDefault": true
             },
             "required": {
               "insertedAsDefault": true
@@ -56,9 +47,6 @@
     "__METADATA__": {
       "primitiveValuesMeta": {
         "type": {
-          "insertedAsDefault": true
-        },
-        "repeat": {
           "insertedAsDefault": true
         },
         "required": {

--- a/src/source/TCK/RAML10/Fragments/test005/Trait-tck.json
+++ b/src/source/TCK/RAML10/Fragments/test005/Trait-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Instagram1.0/api-tck.json
+++ b/src/source/TCK/RAML10/Instagram1.0/api-tck.json
@@ -19,7 +19,6 @@
                 "string"
               ],
               "example": "callbackFunction",
-              "repeat": false,
               "required": true,
               "description": "Callback function name. All output will be wrapper under this function name.\n",
               "__METADATA__": {
@@ -28,9 +27,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -69,16 +65,12 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "description": "Latitude of the center search coordinate. If used, lng is required.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -92,16 +84,12 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "description": "Longitude of the center search coordinate. If used, lat is required.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -116,7 +104,6 @@
                 "integer"
               ],
               "default": 1000,
-              "repeat": false,
               "required": true,
               "description": "Default is 1000m (distance=1000), max distance is 5000.",
               "maximum": 5000,
@@ -124,9 +111,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -159,16 +143,12 @@
                 "integer"
               ],
               "example": 1,
-              "repeat": false,
               "required": true,
               "description": "Number of items you would like to receive.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -206,16 +186,12 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": true,
               "description": "Return media before this UNIX timestamp.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -229,16 +205,12 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": true,
               "description": "Return media after this UNIX timestamp.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -270,16 +242,12 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": true,
               "description": "Return media later than this min_id.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -293,16 +261,12 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": true,
               "description": "Return media earlier than this max_id.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -376,15 +340,11 @@
                         }
                       ]
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -565,15 +525,11 @@
                         }
                       }
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -728,7 +684,6 @@
                       },
                       "data": null
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -736,9 +691,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -792,15 +744,11 @@
                       },
                       "data": null
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -1132,15 +1080,11 @@
                         }
                       ]
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -1371,7 +1315,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Used to send a valid OAuth 2 access token. Do not use together with\nthe \"Authorization\" header\n",
                 "__METADATA__": {
@@ -1380,9 +1323,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -1422,7 +1362,6 @@
                   "string"
                 ],
                 "example": "9e0dbc0a3b8d436ca65ae2df9825c893",
-                "repeat": false,
                 "required": true,
                 "description": "Client_id is is identifier of  your server, script, or program with a specific application\nthis parameter is required if you are accessing APIs without authenticating\n",
                 "__METADATA__": {
@@ -1431,9 +1370,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -1463,7 +1399,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -1475,9 +1410,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -1518,16 +1450,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -1548,7 +1476,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -1557,9 +1484,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -1585,15 +1509,11 @@
                         "type": [
                           "types.Media"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -1645,7 +1565,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "calculated": true,
@@ -1654,9 +1573,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -1680,16 +1596,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -1710,7 +1622,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -1719,9 +1630,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -1747,15 +1655,11 @@
                             "type": [
                               "types.MediaComment"
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -1816,15 +1720,11 @@
                               },
                               "data": null
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -1857,7 +1757,6 @@
                         "type": [
                           "object"
                         ],
-                        "repeat": false,
                         "required": true,
                         "properties": {
                           "text": {
@@ -1866,7 +1765,6 @@
                             "type": [
                               "string"
                             ],
-                            "repeat": false,
                             "required": true,
                             "description": "Text to post as a comment on the media as specified in {mediaId}.",
                             "__METADATA__": {
@@ -1875,9 +1773,6 @@
                                   "calculated": true
                                 },
                                 "type": {
-                                  "insertedAsDefault": true
-                                },
-                                "repeat": {
                                   "insertedAsDefault": true
                                 }
                               }
@@ -1890,9 +1785,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -1961,7 +1853,6 @@
                                   },
                                   "data": null
                                 },
-                                "repeat": false,
                                 "required": true,
                                 "__METADATA__": {
                                   "primitiveValuesMeta": {
@@ -1969,9 +1860,6 @@
                                       "calculated": true
                                     },
                                     "type": {
-                                      "insertedAsDefault": true
-                                    },
-                                    "repeat": {
                                       "insertedAsDefault": true
                                     },
                                     "required": {
@@ -2043,16 +1931,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Identifier of the comment",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -2097,16 +1981,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -2127,7 +2007,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -2136,9 +2015,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -2164,15 +2040,11 @@
                             "type": [
                               "types.MediaLikes"
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -2233,15 +2105,11 @@
                               },
                               "data": null
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -2307,7 +2175,6 @@
                               },
                               "data": null
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
@@ -2315,9 +2182,6 @@
                                   "calculated": true
                                 },
                                 "type": {
-                                  "insertedAsDefault": true
-                                },
-                                "repeat": {
                                   "insertedAsDefault": true
                                 },
                                 "required": {
@@ -2423,16 +2287,12 @@
                     "type": [
                       "integer"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Return media before this UNIX timestamp.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2446,16 +2306,12 @@
                     "type": [
                       "integer"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Return media after this UNIX timestamp.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2469,16 +2325,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Latitude of the center search coordinate. If used, lng is required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2492,16 +2344,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Longitude of the center search coordinate. If used, lat is required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2516,7 +2364,6 @@
                       "integer"
                     ],
                     "default": 1000,
-                    "repeat": false,
                     "required": true,
                     "description": "Default is 1000m (distance=1000), max distance is 5000.",
                     "maximum": 5000,
@@ -2524,9 +2371,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2541,16 +2385,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2571,7 +2411,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -2580,9 +2419,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -2702,15 +2538,11 @@
                             }
                           }
                         },
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -2883,16 +2715,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -2913,7 +2741,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -2922,9 +2749,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -3044,15 +2868,11 @@
                             }
                           }
                         },
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3246,16 +3066,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -3276,7 +3092,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -3285,9 +3100,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -3313,15 +3125,11 @@
                         "type": [
                           "types.Tag"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3373,7 +3181,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Name of tag.",
                 "__METADATA__": {
@@ -3382,9 +3189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -3407,16 +3211,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media later than this min_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3430,16 +3230,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media earlier than this max_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3454,16 +3250,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3484,7 +3276,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -3493,9 +3284,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -3521,15 +3309,11 @@
                             "type": [
                               "types.TagsRecentMedia"
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -3618,7 +3402,6 @@
                       "string"
                     ],
                     "example": "nofilter",
-                    "repeat": false,
                     "required": true,
                     "description": "A valid tag name without a leading #.\n",
                     "__METADATA__": {
@@ -3627,9 +3410,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         }
                       }
@@ -3648,16 +3428,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -3678,7 +3454,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -3687,9 +3462,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -3715,15 +3487,11 @@
                         "type": [
                           "types.TagsSearch"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3818,16 +3586,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -3848,7 +3612,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -3857,9 +3620,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -3885,15 +3645,11 @@
                         "type": [
                           "types.UserAccount"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -3945,7 +3701,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "calculated": true,
@@ -3954,9 +3709,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -3980,16 +3732,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4010,7 +3758,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -4019,9 +3766,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -4072,15 +3816,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -4189,16 +3929,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4219,7 +3955,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -4228,9 +3963,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -4281,15 +4013,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -4397,16 +4125,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media later than this min_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4420,16 +4144,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media earlier than this max_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4443,16 +4163,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media before this UNIX timestamp.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4466,16 +4182,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media after this UNIX timestamp.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4490,16 +4202,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -4520,7 +4228,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -4529,9 +4236,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -4742,15 +4446,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -5015,16 +4715,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5045,7 +4741,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -5054,9 +4749,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -5082,15 +4774,11 @@
                             "type": [
                               "types.Relationships"
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -5151,15 +4839,11 @@
                               },
                               "data": null
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -5192,7 +4876,6 @@
                         "type": [
                           "object"
                         ],
-                        "repeat": false,
                         "required": true,
                         "properties": {
                           "action": {
@@ -5201,7 +4884,6 @@
                             "type": [
                               "string"
                             ],
-                            "repeat": false,
                             "required": true,
                             "description": "One of follow/unfollow/block/unblock/approve/deny.",
                             "enum": [
@@ -5220,9 +4902,6 @@
                                 "type": {
                                   "insertedAsDefault": true
                                 },
-                                "repeat": {
-                                  "insertedAsDefault": true
-                                },
                                 "required": {
                                   "insertedAsDefault": true
                                 }
@@ -5236,9 +4915,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -5324,7 +5000,6 @@
                       "string"
                     ],
                     "example": "some query",
-                    "repeat": false,
                     "required": true,
                     "description": "A query string.",
                     "__METADATA__": {
@@ -5333,9 +5008,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         }
                       }
@@ -5354,16 +5026,12 @@
                       "integer"
                     ],
                     "example": 10,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of users to return.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -5384,7 +5052,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -5393,9 +5060,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -5446,15 +5110,11 @@
                             }
                           ]
                         },
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5563,16 +5223,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -5593,7 +5249,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -5602,9 +5257,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -5630,15 +5282,11 @@
                         "type": [
                           "types.UserAccount"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5710,16 +5358,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media later than this min_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5733,16 +5377,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media earlier than this max_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5757,16 +5397,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -5787,7 +5423,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -5796,9 +5431,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -6009,15 +5641,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -6280,16 +5908,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -6310,7 +5934,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -6319,9 +5942,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -6372,15 +5992,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -6489,16 +6105,12 @@
                           "integer"
                         ],
                         "example": 100,
-                        "repeat": false,
                         "required": true,
                         "description": "Return media liked before this id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -6519,16 +6131,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -6549,7 +6157,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -6558,9 +6165,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -6771,15 +6375,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -7077,16 +6677,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -7107,7 +6703,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -7116,9 +6711,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -7144,15 +6736,11 @@
                         "type": [
                           "types.Location"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7204,15 +6792,11 @@
                 "type": [
                   "integer"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -7234,16 +6818,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media later than this min_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7257,16 +6837,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media earlier than this max_id.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7280,16 +6856,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media before this UNIX timestamp.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7303,16 +6875,12 @@
                         "type": [
                           "integer"
                         ],
-                        "repeat": false,
                         "required": true,
                         "description": "Return media after this UNIX timestamp.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7327,16 +6895,12 @@
                           "integer"
                         ],
                         "example": 1,
-                        "repeat": false,
                         "required": true,
                         "description": "Number of items you would like to receive.",
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -7357,7 +6921,6 @@
                           "string"
                         ],
                         "example": "callbackFunction",
-                        "repeat": false,
                         "required": true,
                         "description": "Callback function name. All output will be wrapper under this function name.\n",
                         "__METADATA__": {
@@ -7366,9 +6929,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -7579,15 +7139,11 @@
                                 }
                               ]
                             },
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true
@@ -7866,7 +7422,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Returns a location mapped off of a foursquare v2 api location id. If\nused, you are not required to use lat and lng.\n",
                     "__METADATA__": {
@@ -7875,9 +7430,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -7892,7 +7444,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Returns a location mapped off of a foursquare v1 api location id. If used,\nyou are not required to use lat and lng. Note that this method is deprecated;\nyou should use the new foursquare IDs with V2 of their API.\n",
                     "__METADATA__": {
@@ -7901,9 +7452,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -7918,16 +7466,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Latitude of the center search coordinate. If used, lng is required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -7941,16 +7485,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Longitude of the center search coordinate. If used, lat is required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -7965,7 +7505,6 @@
                       "integer"
                     ],
                     "default": 1000,
-                    "repeat": false,
                     "required": true,
                     "description": "Default is 1000m (distance=1000), max distance is 5000.",
                     "maximum": 5000,
@@ -7973,9 +7512,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -7990,16 +7526,12 @@
                       "integer"
                     ],
                     "example": 1,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of items you would like to receive.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -8020,7 +7552,6 @@
                       "string"
                     ],
                     "example": "callbackFunction",
-                    "repeat": false,
                     "required": true,
                     "description": "Callback function name. All output will be wrapper under this function name.\n",
                     "__METADATA__": {
@@ -8029,9 +7560,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -8057,15 +7585,11 @@
                         "type": [
                           "types.Locations"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -8153,16 +7677,12 @@
                   "integer"
                 ],
                 "example": 0,
-                "repeat": false,
                 "required": true,
                 "description": "Return media before this min_id.",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -8183,16 +7703,12 @@
                   "integer"
                 ],
                 "example": 1,
-                "repeat": false,
                 "required": true,
                 "description": "Number of items you would like to receive.",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -8213,7 +7729,6 @@
                   "string"
                 ],
                 "example": "callbackFunction",
-                "repeat": false,
                 "required": true,
                 "description": "Callback function name. All output will be wrapper under this function name.\n",
                 "__METADATA__": {
@@ -8222,9 +7737,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -8286,7 +7798,6 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "calculated": true,
@@ -8295,9 +7806,6 @@
                   "calculated": true
                 },
                 "type": {
-                  "insertedAsDefault": true
-                },
-                "repeat": {
                   "insertedAsDefault": true
                 },
                 "required": {
@@ -8336,7 +7844,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Application's client id",
                 "__METADATA__": {
@@ -8345,9 +7852,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     }
                   }
@@ -8359,7 +7863,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Application's client secret",
                 "__METADATA__": {
@@ -8368,9 +7871,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     }
                   }
@@ -8383,16 +7883,12 @@
                   "integer"
                 ],
                 "example": 1,
-                "repeat": false,
                 "required": true,
                 "description": "Number of items you would like to receive.",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -8413,7 +7909,6 @@
                   "string"
                 ],
                 "example": "callbackFunction",
-                "repeat": false,
                 "required": true,
                 "description": "Callback function name. All output will be wrapper under this function name.\n",
                 "__METADATA__": {
@@ -8422,9 +7917,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -8450,15 +7942,11 @@
                     "type": [
                       "types.SubscriptionsGet"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -8504,15 +7992,11 @@
                     "type": [
                       "types.SubscriptionPost"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -8534,7 +8018,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "client_id": {
@@ -8543,7 +8026,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Application's client id",
                     "__METADATA__": {
@@ -8552,9 +8034,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         }
                       }
@@ -8566,7 +8045,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Application's client secret",
                     "__METADATA__": {
@@ -8575,9 +8053,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         }
                       }
@@ -8589,7 +8064,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "The object you'd like to subscribe to.",
                     "enum": [
@@ -8606,9 +8080,6 @@
                         "type": {
                           "insertedAsDefault": true
                         },
-                        "repeat": {
-                          "insertedAsDefault": true
-                        },
                         "required": {
                           "insertedAsDefault": true
                         }
@@ -8621,7 +8092,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Used for user, location and tag subscriptions only. Required. In case of user and location represents 'id' of the desired object. In case of tag represents 'name' of the desired tag.",
                     "__METADATA__": {
@@ -8630,9 +8100,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -8647,7 +8114,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "The aspect of the object you'd like to subscribe to. Note that we only support \"media\" at this time, but we might support other types of subscriptions in the future.\n",
                     "__METADATA__": {
@@ -8656,9 +8122,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -8673,7 +8136,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "When we have new updates to send your server, we do a simple POST with a payload containing updates to a URL on your server. This callback URL must support GET and POST methods.\n\nWhen you add a subscription, we will send a GET request to your callback URL to verify the existence of the URL and that want to create the subscription. When we have new data, we'll POST this data to your callback URL. We'll explain more about what this URL needs to do later on this page.\n",
                     "__METADATA__": {
@@ -8682,9 +8144,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         }
                       }
@@ -8696,14 +8155,10 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Geography area's center latitude. Used for geography subscription only. Required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
-                        "repeat": {
-                          "insertedAsDefault": true
-                        },
                         "required": {
                           "insertedAsDefault": true
                         }
@@ -8716,16 +8171,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Geography area's center longitude. Used for geography subscription only. Required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -8739,16 +8190,12 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "Geography area's radius.Used for geography subscription only. Required.",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -8763,9 +8210,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -8803,7 +8247,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Application's client id",
                 "__METADATA__": {
@@ -8812,9 +8255,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     }
                   }
@@ -8826,7 +8266,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Application's client secret",
                 "__METADATA__": {
@@ -8835,9 +8274,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     }
                   }
@@ -8849,7 +8285,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Id of subscription to be removed.",
                 "__METADATA__": {
@@ -8858,9 +8293,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -8875,7 +8307,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "If you'd like to remove all subscriptions of a certain object type, you may include the object type. Also you can clear all your current subscriptions by setting 'object' to 'all'.",
                 "enum": [
@@ -8891,9 +8322,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -8913,15 +8341,11 @@
                     "type": [
                       "types.SubscriptionsDelete"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Libraries/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Libraries/test001/api-tck.json
@@ -16,7 +16,6 @@
           "type": [
             "ll.Person"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name2": {
@@ -25,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -46,9 +41,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/MediaTypes/test002/api-tck.json
+++ b/src/source/TCK/RAML10/MediaTypes/test002/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -18,9 +17,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -50,15 +46,11 @@
                     "type": [
                       "Person[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -72,15 +64,11 @@
                     "type": [
                       "Person[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -117,15 +105,11 @@
                 "type": [
                   "Person"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -139,15 +123,11 @@
                 "type": [
                   "Person"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/MethodResponses/test001/methResp01-tck.json
+++ b/src/source/TCK/RAML10/MethodResponses/test001/methResp01-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,8 +61,8 @@
         "methods": [
           {
             "responses": {
-              "20x": {
-                "code": "20x"
+              "200": {
+                "code": "200"
               }
             },
             "method": "get"

--- a/src/source/TCK/RAML10/MethodResponses/test001/methResp01.raml
+++ b/src/source/TCK/RAML10/MethodResponses/test001/methResp01.raml
@@ -10,4 +10,4 @@ types:
 /test:
   get:
     responses:
-      20x:
+      200:

--- a/src/source/TCK/RAML10/MethodResponses/test002/methResp02-tck.json
+++ b/src/source/TCK/RAML10/MethodResponses/test002/methResp02-tck.json
@@ -8,8 +8,8 @@
         "methods": [
           {
             "responses": {
-              "20x": {
-                "code": "20x",
+              "200": {
+                "code": "200",
                 "body": {
                   "application/json": {
                     "name": "application/json",
@@ -17,7 +17,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -25,9 +24,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/MethodResponses/test002/methResp02.raml
+++ b/src/source/TCK/RAML10/MethodResponses/test002/methResp02.raml
@@ -3,6 +3,6 @@ title: test
 /test:
   get:
     responses:
-      20x:
+      200:
         body: 
           application/json:

--- a/src/source/TCK/RAML10/MethodResponses/test003/methResp03-tck.json
+++ b/src/source/TCK/RAML10/MethodResponses/test003/methResp03-tck.json
@@ -17,7 +17,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -25,9 +24,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -42,7 +38,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -50,9 +45,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -67,7 +59,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -75,9 +66,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -92,7 +80,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -100,9 +87,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -117,7 +101,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -125,9 +108,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -142,7 +122,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -150,9 +129,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -167,7 +143,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -175,9 +150,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -192,7 +164,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -200,9 +171,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -217,7 +185,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -225,9 +192,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -242,7 +206,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -250,9 +213,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -267,7 +227,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -275,9 +234,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -307,5 +263,26 @@
       }
     ]
   },
-  "errors": []
+  "errors": [
+    {
+      "code": 7,
+      "message": "Status code should be 3 digits number.",
+      "path": "methResp03.raml",
+      "line": 5,
+      "column": 6,
+      "position": 59,
+      "range": [
+        {
+          "line": 5,
+          "column": 6,
+          "position": 59
+        },
+        {
+          "line": 5,
+          "column": 9,
+          "position": 62
+        }
+      ]
+    }
+  ]
 }

--- a/src/source/TCK/RAML10/MethodResponses/test004/methResp04-tck.json
+++ b/src/source/TCK/RAML10/MethodResponses/test004/methResp04-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -78,15 +70,11 @@
                     "type": [
                       "TestType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/MethodResponses/test005/methResp05-tck.json
+++ b/src/source/TCK/RAML10/MethodResponses/test005/methResp05-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,7 +33,6 @@
           "example": {
             "id": "userId"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -67,9 +58,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,7 +85,6 @@
             "id": "userId",
             "username": "name"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "username": {
@@ -106,15 +93,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -127,9 +110,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -167,7 +147,6 @@
                       "username": "base",
                       "id": "any text"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "additionalField": {
@@ -176,15 +155,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": false,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -197,9 +172,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Methods/test001/meth01-tck.json
+++ b/src/source/TCK/RAML10/Methods/test001/meth01-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"type\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -43,7 +39,6 @@
                     "schema": [
                       "TestSchema"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -51,9 +46,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Methods/test002/meth02-tck.json
+++ b/src/source/TCK/RAML10/Methods/test002/meth02-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"type\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -45,7 +41,6 @@
                 "schema": [
                   "TestSchema"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -53,9 +48,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test004/meth04-tck.json
+++ b/src/source/TCK/RAML10/Methods/test004/meth04-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"type\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -44,16 +40,12 @@
                       "integer"
                     ],
                     "example": 10,
-                    "repeat": false,
                     "required": true,
                     "description": "Number of seconds to wait.\n",
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         }
                       }
                     },
@@ -74,7 +66,6 @@
                 "schema": [
                   "TestSchema"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -82,9 +73,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test005/meth05-tck.json
+++ b/src/source/TCK/RAML10/Methods/test005/meth05-tck.json
@@ -14,7 +14,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "The status.",
                 "enum": [
@@ -28,9 +27,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     }
                   }
@@ -49,7 +45,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -57,9 +52,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test006/meth06-tck.json
+++ b/src/source/TCK/RAML10/Methods/test006/meth06-tck.json
@@ -19,7 +19,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -27,9 +26,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test007/meth07-tck.json
+++ b/src/source/TCK/RAML10/Methods/test007/meth07-tck.json
@@ -19,7 +19,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -27,9 +26,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test008/meth08-tck.json
+++ b/src/source/TCK/RAML10/Methods/test008/meth08-tck.json
@@ -19,7 +19,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -27,9 +26,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test009/meth09-tck.json
+++ b/src/source/TCK/RAML10/Methods/test009/meth09-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -78,15 +70,11 @@
                     "type": [
                       "TestType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -104,15 +92,11 @@
                 "type": [
                   "TestType"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Methods/test010/meth10-tck.json
+++ b/src/source/TCK/RAML10/Methods/test010/meth10-tck.json
@@ -14,7 +14,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -22,9 +21,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -39,7 +35,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -47,9 +42,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -64,7 +56,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -72,9 +63,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -89,7 +77,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -97,9 +84,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -114,7 +98,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -122,9 +105,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -139,7 +119,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -147,9 +126,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -164,7 +140,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -172,9 +147,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -189,7 +161,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -197,9 +168,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -214,7 +182,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -222,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -239,7 +203,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -247,9 +210,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -264,7 +224,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -272,9 +231,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Methods/test011/meth11-tck.json
+++ b/src/source/TCK/RAML10/Methods/test011/meth11-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -75,15 +67,11 @@
                 "type": [
                   "TestType"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Methods/test012/meth12-tck.json
+++ b/src/source/TCK/RAML10/Methods/test012/meth12-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,7 +33,6 @@
           "example": {
             "baseField": "name"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "baseField": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -67,9 +58,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,7 +85,6 @@
             "baseField": "name",
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -106,15 +93,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -127,9 +110,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -167,7 +147,6 @@
                       "baseField": "base",
                       "field": "any text"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "additionalField": {
@@ -176,15 +155,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": false,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -197,9 +172,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -226,7 +198,6 @@
                 "schema": [
                   "account"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -234,9 +205,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Overlays/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test005/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Overlays/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test006/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Overlays/test007/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test007/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Overlays/test008/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test008/api-tck.json
@@ -20,15 +20,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,15 +38,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -71,7 +63,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -80,15 +71,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -103,9 +90,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Overlays/test012/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test012/api-tck.json
@@ -29,7 +29,6 @@
                         }
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -37,9 +36,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Overlays/test013/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test013/api-tck.json
@@ -27,7 +27,6 @@
                         }
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -35,9 +34,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Overlays/test014/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test014/api-tck.json
@@ -35,7 +35,6 @@
                         }
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -43,9 +42,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Overlays/test015/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test015/api-tck.json
@@ -20,7 +20,6 @@
                     "example": {
                       "content": 9
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -28,9 +27,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Overlays/test016/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test016/api-tck.json
@@ -20,7 +20,6 @@
                     "example": {
                       "content": 9
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -28,9 +27,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Overlays/test018/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test018/api-tck.json
@@ -14,7 +14,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "name": {
@@ -24,15 +23,11 @@
                       "string"
                     ],
                     "default": "Blah",
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -45,9 +40,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Overlays/test019/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test019/api-tck.json
@@ -28,7 +28,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "name": {
@@ -38,15 +37,11 @@
                       "string"
                     ],
                     "default": "Blah",
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -59,9 +54,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Overlays/test020/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test020/api-tck.json
@@ -14,7 +14,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "name": {
@@ -24,15 +23,11 @@
                       "string"
                     ],
                     "default": "Blah",
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -45,9 +40,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Overlays/test021/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test021/api-tck.json
@@ -17,7 +17,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "name": {
@@ -27,15 +26,11 @@
                       "string"
                     ],
                     "default": "Blah",
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -48,9 +43,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Overlays/test026/apigateway-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test026/apigateway-tck.json
@@ -21,7 +21,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -29,9 +28,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -110,7 +106,6 @@
                 "type": [
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Latitude component of location",
                 "format": "double",
@@ -121,9 +116,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }
@@ -134,7 +126,6 @@
                 "type": [
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Longitude component of location",
                 "format": "double",
@@ -145,9 +136,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     }
                   }
                 }

--- a/src/source/TCK/RAML10/Overlays/test028/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test028/api-tck.json
@@ -20,15 +20,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,15 +38,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -71,7 +63,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -80,15 +71,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -103,9 +90,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/ResourceTypes/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test001/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -92,15 +80,11 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -131,15 +115,11 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test002/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -92,15 +80,11 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -127,15 +111,11 @@
                 "type": [
                   "User"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -161,15 +141,11 @@
                 "type": [
                   "User"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -191,15 +167,11 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test003/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test004/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test005/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test006/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test006/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -304,7 +264,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -312,9 +271,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -356,7 +312,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -365,15 +320,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -387,15 +338,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -408,9 +355,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromType1": "stringValue1",
                   "propertyFromResourceType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromType1": "stringValue1",
                   "propertyFromResourceType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test007/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test007/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromType1": "stringValue1",
                   "propertyFromResourceType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromType1": "stringValue1",
                   "propertyFromResourceType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test008/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test008/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test009/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test009/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -303,7 +263,6 @@
                   "propertyFromType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -311,9 +270,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -354,7 +310,6 @@
                   "propertyFromType1": "stringValue1",
                   "extraProperty": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -363,15 +318,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -385,15 +336,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -406,9 +353,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -302,7 +262,6 @@
                 "example": {
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -310,9 +269,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -352,7 +308,6 @@
                   "propertyFromType2": "stringValue3",
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -361,15 +316,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -383,15 +334,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -404,9 +351,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test010/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test010/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -302,7 +262,6 @@
                 "example": {
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -310,9 +269,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -352,7 +308,6 @@
                   "propertyFromType1": "stringValue3",
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -361,15 +316,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -383,15 +334,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -404,9 +351,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/ResourceTypes/test011/apiValid-tck.json
+++ b/src/source/TCK/RAML10/ResourceTypes/test011/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test001/apiInvalid-tck.json
@@ -21,7 +21,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "some very useful resource",
                     "__METADATA__": {
@@ -30,9 +29,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -70,7 +66,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "another very useful resource",
                     "__METADATA__": {
@@ -79,9 +74,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Resources/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test001/apiValid-tck.json
@@ -21,7 +21,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "some very useful resource",
                     "__METADATA__": {
@@ -30,9 +29,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -70,7 +66,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "another very useful resource",
                     "__METADATA__": {
@@ -79,9 +74,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Resources/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test002/apiInvalid-tck.json
@@ -21,7 +21,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "some very useful resource",
                     "__METADATA__": {
@@ -30,9 +29,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -64,7 +60,6 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "calculated": true,
@@ -73,9 +68,6 @@
                   "calculated": true
                 },
                 "type": {
-                  "insertedAsDefault": true
-                },
-                "repeat": {
                   "insertedAsDefault": true
                 },
                 "required": {
@@ -90,15 +82,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test002/apiValid-tck.json
@@ -21,7 +21,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "description": "some very useful resource",
                     "__METADATA__": {
@@ -30,9 +29,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -64,15 +60,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test003/apiInvalid-tck.json
@@ -25,7 +25,6 @@
                       "name": "john",
                       "age": "34s"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "name": {
@@ -34,15 +33,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -56,15 +51,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -77,9 +68,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -119,15 +107,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test003/apiValid-tck.json
@@ -25,7 +25,6 @@
                       "name": "john",
                       "age": 34
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "name": {
@@ -34,15 +33,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -56,15 +51,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -77,9 +68,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -119,15 +107,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test004/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,15 +85,11 @@
                       "name": "john",
                       "age": "34s"
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -145,15 +129,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test004/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,15 +85,11 @@
                       "name": "john",
                       "age": 34
                     },
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -145,15 +129,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test005/apiInvalid-tck.json
@@ -22,7 +22,6 @@
                   "name": "john",
                   "age": "342w"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "name": {
@@ -31,15 +30,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -53,15 +48,11 @@
                     "type": [
                       "number"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -74,9 +65,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -114,15 +102,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test005/apiValid-tck.json
@@ -25,7 +25,6 @@
                       "name": "john",
                       "age": 34
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "name": {
@@ -34,15 +33,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -56,15 +51,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -77,9 +68,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -119,15 +107,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test006/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test006/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -94,15 +82,11 @@
                   "name": "john",
                   "age": "34s"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -140,15 +124,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test006/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test006/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -94,15 +82,11 @@
                   "name": "john",
                   "age": 34
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -140,15 +124,11 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "primitiveValuesMeta": {
                 "displayName": {
                   "calculated": true
-                },
-                "repeat": {
-                  "insertedAsDefault": true
                 },
                 "required": {
                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test007/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test007/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test007/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test007/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test008/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test008/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test008/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test008/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test009/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test009/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test009/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test009/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test010/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test010/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test010/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test010/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -119,7 +103,6 @@
                 "type": [
                   "<<bodyTypeParam>>"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -128,15 +111,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -149,9 +128,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,7 +151,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -184,15 +159,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -207,9 +178,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -234,7 +202,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -243,15 +210,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -266,9 +229,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -300,7 +260,6 @@
                   "propertyFromResourceType2": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -309,15 +268,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -331,15 +286,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -352,9 +303,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test011/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test011/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "extraProperty1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "propertyFromResourceType1": "stringValue3",
                   "extraProperty1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test011/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test011/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "propertyFromResourceType1": "stringValue3",
                   "extraProperty": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test012/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test012/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "propertyFromType2": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "extraProperty": "stringValue3",
                   "propertyFromType2": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test012/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test012/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "propertyFromType1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "extraProperty": "stringValue3",
                   "propertyFromType1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test013/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test013/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "propertyFromResourceType2": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "extraProperty": "stringValue3",
                   "propertyFromResourceType2": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test013/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test013/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -122,7 +106,6 @@
                 "example": {
                   "propertyFromResourceType1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -131,15 +114,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -152,9 +131,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -186,7 +162,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -195,15 +170,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -218,9 +189,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -245,7 +213,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -254,15 +221,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -277,9 +240,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -311,7 +271,6 @@
                   "extraProperty": "stringValue3",
                   "propertyFromResourceType1": "stringValue1"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -320,15 +279,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -342,15 +297,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -363,9 +314,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test014/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test014/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -123,7 +107,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "propertyFromType2": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -132,15 +115,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -153,9 +132,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -188,7 +164,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -197,15 +172,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -220,9 +191,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -247,7 +215,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -256,15 +223,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -279,9 +242,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -313,7 +273,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "propertyFromType2": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -322,15 +281,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -344,15 +299,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -365,9 +316,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test014/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test014/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -123,7 +107,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "propertyFromType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -132,15 +115,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -153,9 +132,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -188,7 +164,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -197,15 +172,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -220,9 +191,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -247,7 +215,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -256,15 +223,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -279,9 +242,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -313,7 +273,6 @@
                   "propertyFromResourceType1": "stringValue1",
                   "propertyFromType1": "stringValue2"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -322,15 +281,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -344,15 +299,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -365,9 +316,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test015/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test015/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -124,7 +108,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -133,15 +116,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -154,9 +133,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -190,7 +166,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -199,15 +174,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -222,9 +193,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -249,7 +217,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -258,15 +225,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -281,9 +244,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -315,7 +275,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -324,15 +283,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -346,15 +301,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -367,9 +318,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Resources/test015/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Resources/test015/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "propertyFromType2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -124,7 +108,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -133,15 +116,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -154,9 +133,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -190,7 +166,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType1": {
@@ -199,15 +174,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -222,9 +193,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -249,7 +217,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "propertyFromResourceType2": {
@@ -258,15 +225,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -281,9 +244,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -315,7 +275,6 @@
                   "propertyFromType1": "stringValue2",
                   "extraProperty": "stringValue3"
                 },
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "extraProperty": {
@@ -324,15 +283,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -346,15 +301,11 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -367,9 +318,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Responses/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test001/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,8 +61,8 @@
         "methods": [
           {
             "responses": {
-              "20x": {
-                "code": "20x"
+              "200": {
+                "code": "200"
               }
             },
             "method": "get"

--- a/src/source/TCK/RAML10/Responses/test001/api.raml
+++ b/src/source/TCK/RAML10/Responses/test001/api.raml
@@ -10,4 +10,4 @@ types:
 /test:
   get:
     responses:
-      20x:
+      200:

--- a/src/source/TCK/RAML10/Responses/test002/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test002/api-tck.json
@@ -8,8 +8,8 @@
         "methods": [
           {
             "responses": {
-              "20x": {
-                "code": "20x",
+              "200": {
+                "code": "200",
                 "body": {
                   "application/json": {
                     "name": "application/json",
@@ -17,7 +17,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -25,9 +24,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Responses/test002/api.raml
+++ b/src/source/TCK/RAML10/Responses/test002/api.raml
@@ -3,6 +3,6 @@ title: test
 /test:
   get:
     responses:
-      20x:
+      200:
         body: 
           application/json:

--- a/src/source/TCK/RAML10/Responses/test003/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test003/api-tck.json
@@ -8,8 +8,8 @@
         "methods": [
           {
             "responses": {
-              "2xx": {
-                "code": "2xx",
+              "200": {
+                "code": "200",
                 "body": {
                   "application/json": {
                     "name": "application/json",
@@ -17,7 +17,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -25,9 +24,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -42,7 +38,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -50,9 +45,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -67,7 +59,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -75,9 +66,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -92,7 +80,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -100,9 +87,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -117,7 +101,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -125,9 +108,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -142,7 +122,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -150,9 +129,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -167,7 +143,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -175,9 +150,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -192,7 +164,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -200,9 +171,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -217,7 +185,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -225,9 +192,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -242,7 +206,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -250,9 +213,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -267,7 +227,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -275,9 +234,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Responses/test003/api.raml
+++ b/src/source/TCK/RAML10/Responses/test003/api.raml
@@ -3,7 +3,7 @@ title: test
 /test:
   post:
     responses:
-      2xx:
+      200:
         body:
           application/json:
           application/vnd.xara:

--- a/src/source/TCK/RAML10/Responses/test004/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test004/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "field": "value"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "field": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -78,15 +70,11 @@
                     "type": [
                       "TestType"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Responses/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test005/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-03/schema\",\n  \"type\": \"object\" ,\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"type\": \"string\"\n    }\n  }\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,7 +33,6 @@
           "example": {
             "id": "userId"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -46,15 +41,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -67,9 +58,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,7 +85,6 @@
             "id": "userId",
             "username": "name"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "username": {
@@ -106,15 +93,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -127,9 +110,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -167,7 +147,6 @@
                       "username": "base",
                       "id": "any text"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "additionalField": {
@@ -176,15 +155,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": false,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -197,9 +172,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Responses/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Responses/test006/api-tck.json
@@ -17,7 +17,6 @@
                     "schema": [
                       "{\"name\": \"someName\"}\n"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -25,9 +24,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test002/apiInvalid-tck.json
@@ -16,16 +16,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Used to send a valid OAuth 2 access token. Do not use with\nthe \"Authorization\" header.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -41,16 +37,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Used to send a valid OAuth 2 access token. Do not use\nwith the \"access_token\" query string parameter.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/SecuritySchemes/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test002/apiValid-tck.json
@@ -16,16 +16,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Used to send a valid OAuth 2 access token. Do not use with\nthe \"Authorization\" header.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -41,16 +37,12 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "description": "Used to send a valid OAuth 2 access token. Do not use\nwith the \"access_token\" query string parameter.\n",
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/SecuritySchemes/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test003/apiInvalid-tck.json
@@ -22,7 +22,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -34,9 +33,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test003/apiValid-tck.json
@@ -26,7 +26,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -38,9 +37,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test004/apiInvalid-tck.json
@@ -22,7 +22,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -34,9 +33,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test004/apiValid-tck.json
@@ -28,7 +28,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -40,9 +39,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test005/apiInvalid-tck.json
@@ -30,7 +30,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -42,9 +41,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/SecuritySchemes/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/SecuritySchemes/test005/apiValid-tck.json
@@ -32,7 +32,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -44,9 +43,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/TemplateTransformers/test001/t1-tck.json
+++ b/src/source/TCK/RAML10/TemplateTransformers/test001/t1-tck.json
@@ -65,7 +65,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "1"
@@ -77,9 +76,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {

--- a/src/source/TCK/RAML10/Traits/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test001/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty2": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test001/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty1": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test002/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty1": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test002/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty1": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test003/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty2": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test003/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty2": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test004/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty2": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Traits/test004/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "rtTypeProperty2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -93,9 +80,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -112,7 +96,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty1": {
@@ -121,15 +104,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -144,9 +123,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -163,7 +139,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "typeProperty2": {
@@ -172,15 +147,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -195,9 +166,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,15 +186,11 @@
               "type": [
                 "<<RTType>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -250,7 +214,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -259,15 +222,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -281,15 +240,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -303,15 +258,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -326,9 +277,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -355,7 +303,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "traitProperty1": {
@@ -364,15 +311,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -386,15 +329,11 @@
                       "type": [
                         "boolean"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -408,15 +347,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -431,9 +366,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -496,7 +428,6 @@
                     "type": [
                       "object"
                     ],
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -505,15 +436,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -527,15 +454,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -549,15 +472,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -571,15 +490,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -594,9 +509,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -618,15 +530,11 @@
                 "example": {
                   "rtTypeProperty2": "stringValue"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -669,7 +577,6 @@
                       "traitProperty1_3": "stringValue1",
                       "traitProperty2_3": "stringValue2"
                     },
-                    "repeat": false,
                     "required": true,
                     "properties": {
                       "traitProperty1": {
@@ -678,15 +585,11 @@
                         "type": [
                           "number"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -700,15 +603,11 @@
                         "type": [
                           "boolean"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -722,15 +621,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -744,15 +639,11 @@
                         "type": [
                           "string"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -767,9 +658,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Traits/test005/api-tck.json
@@ -50,7 +50,6 @@
                         "structuredValue": "<doc><property2>value2</property2></doc>\n"
                       }
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
@@ -58,9 +57,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {

--- a/src/source/TCK/RAML10/Traits/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Traits/test006/api-tck.json
@@ -12,15 +12,11 @@
               "type": [
                 "<<type1>>"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -50,15 +46,11 @@
                 "type": [
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -77,7 +69,6 @@
                 "example": {
                   "prop": "value"
                 },
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -85,9 +76,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Types/External Types/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test001/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"properties\": {\n    \"auth_token\": {\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"uri\": {\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"date_created\": {\n      \"description\": \"The date that this account was created, in GMT in RFC 2822 format\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"date_updated\": {\n      \"description\": \"The date that this account was last updated, in GMT in RFC 2822 format.\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"friendly_name\": {\n      \"description\": \"A human readable description of this account, up to 64 characters long. By default the FriendlyName is your email address.\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"sid\": {\n      \"description\": \"A 34 character string that uniquely identifies this account.\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"status\": {\n      \"description\": \"The status of this account. Usually active, but can be suspended or closed.\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"type\": {\n      \"description\": \"The type of this account. Either Trial or Full if you've upgraded.\",\n      \"required\": false,\n      \"type\": \"string\"\n    },\n    \"subresource_uris\": {\n      \"type\": \"object\",\n      \"required\": false\n    }\n  },\n  \"required\": false,\n  \"type\": \"object\"\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test002/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test002/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "<xs:schema attributeFormDefault=\"unqualified\" elementFormDefault=\"qualified\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n    <xs:element name=\"TwilioResponse\">\n        <xs:complexType>\n            <xs:sequence>\n                <xs:element name=\"Account\">\n                    <xs:complexType>\n                        <xs:sequence>\n                            <xs:element type=\"xs:string\" name=\"Sid\"/>\n                            <xs:element type=\"xs:string\" name=\"FriendlyName\"/>\n                            <xs:element type=\"xs:string\" name=\"Type\"/>\n                            <xs:element type=\"xs:string\" name=\"Status\"/>\n                            <xs:element type=\"xs:string\" name=\"DateCreated\"/>\n                            <xs:element type=\"xs:string\" name=\"DateUpdated\"/>\n                            <xs:element type=\"xs:string\" name=\"AuthToken\"/>\n                            <xs:element type=\"xs:string\" name=\"Uri\"/>\n                            <xs:element name=\"SubresourceUris\">\n                                <xs:complexType>\n                                    <xs:sequence>\n                                        <xs:element type=\"xs:string\" name=\"AvailablePhoneNumbers\"/>\n                                        <xs:element type=\"xs:string\" name=\"Calls\"/>\n                                        <xs:element type=\"xs:string\" name=\"Conferences\"/>\n                                        <xs:element type=\"xs:string\" name=\"IncomingPhoneNumbers\"/>\n                                        <xs:element type=\"xs:string\" name=\"Notifications\"/>\n                                        <xs:element type=\"xs:string\" name=\"OutgoingCallerIds\"/>\n                                        <xs:element type=\"xs:string\" name=\"Recordings\"/>\n                                        <xs:element type=\"xs:string\" name=\"Sandbox\"/>\n                                        <xs:element type=\"xs:string\" name=\"SMSMessages\"/>\n                                        <xs:element type=\"xs:string\" name=\"Transcriptions\"/>\n                                    </xs:sequence>\n                                </xs:complexType>\n                            </xs:element>\n                        </xs:sequence>\n                    </xs:complexType>\n                </xs:element>\n            </xs:sequence>\n        </xs:complexType>\n    </xs:element>\n</xs:schema>"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test003/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test003/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "Raw text."
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test004/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test004/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  properties: {\n  \"auth_token\": {\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"uri\": {\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"date_created\": {\n    \"description\": \"The date that this account was created, in GMT in RFC 2822 format\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"date_updated\": {\n    \"description\": \"The date that this account was last updated, in GMT in RFC 2822 format.\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"friendly_name\": {\n    \"description\": \"A human readable description of this account, up to 64 characters long. By default the FriendlyName is your email address.\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"sid\": {\n    \"description\": \"A 34 character string that uniquely identifies this account.\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"status\": {\n    \"description\": \"The status of this account. Usually active, but can be suspended or closed.\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"type\": {\n    \"description\": \"The type of this account. Either Trial or Full if you've upgraded.\",\n    \"required\": false,\n    \"type\": \"string\"\n  },\n  \"subresource_uris\": {\n    \"type\": \"object\",\n    \"required\": false\n  }\n},\n\"required\": false,\n\"type\": \"object\"\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test005/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"title\": \"Product\",\n  \"description\": \"A product from Acme's catalog\",\n  \"type\": \"object\",\n  \"properties\": {\n      \"id\": {\n          \"description\": \"The unique identifier for a product\",\n          \"type\": \"string\"\n      }\n  },\n  \"required\": [\"id\"]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,15 +33,11 @@
           "example": {
             "message": 2
           },
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -72,15 +64,11 @@
           "example": {
             "id": "4"
           },
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test006/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"title\": \"Product\",\n  \"description\": \"A product from Acme's catalog\",\n  \"type\": \"object\",\n  \"properties\": {\n      \"id\": {\n          \"description\": \"The unique identifier for a product\",\n          \"type\": \"string\"\n      }\n  },\n  \"required\": [\"id\"]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,15 +33,11 @@
           "example": {
             "id": "4"
           },
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/External Types/test007/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test007/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"title\": \"Product\",\n  \"description\": \"A product from Acme's catalog\",\n  \"type\": \"object\",\n  \"properties\": {\n      \"id\": {\n          \"description\": \"The unique identifier for a product\",\n          \"type\": \"string\"\n      }\n  },\n  \"required\": [\"id\"]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -37,7 +33,6 @@
           "example": {
             "c": 4
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -46,15 +41,11 @@
               "type": [
                 "mySchema"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -69,9 +60,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/External Types/test008/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test008/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"title\": \"Product\",\n  \"description\": \"A product from Acme's catalog\",\n  \"type\": \"object\",\n  \"properties\": {\n      \"id\": {\n          \"description\": \"The unique identifier for a product\",\n          \"type\": \"string\"\n      }\n  },\n  \"required\": [\"id\"]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -39,7 +35,6 @@
               "i": 2
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -48,15 +43,11 @@
               "type": [
                 "mySchema"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -71,9 +62,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/External Types/test009/api-tck.json
+++ b/src/source/TCK/RAML10/Types/External Types/test009/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"title\": \"Product\",\n  \"description\": \"A product from Acme's catalog\",\n  \"type\": \"object\",\n  \"properties\": {\n      \"id\": {\n          \"description\": \"The unique identifier for a product\",\n          \"type\": \"string\"\n      }\n  },\n  \"required\": [\"id\"]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -39,7 +35,6 @@
               "id": "2"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "c": {
@@ -48,15 +43,11 @@
               "type": [
                 "mySchema"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -71,9 +62,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/Facets/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Facets/test001/api-tck.json
@@ -24,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +40,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -68,7 +60,6 @@
           "type": [
             "myDate"
           ],
-          "repeat": false,
           "required": true,
           "fixedFacets": {
             "format": "YYYY"
@@ -77,9 +68,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -97,15 +85,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -121,15 +105,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -151,15 +131,11 @@
                 "type": [
                   "year"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Facets/test002/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Facets/test002/api-tck.json
@@ -24,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +40,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -68,7 +60,6 @@
           "type": [
             "myDate"
           ],
-          "repeat": false,
           "required": true,
           "fixedFacets": {
             "format": "YYYY"
@@ -77,9 +68,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -95,7 +83,6 @@
           "type": [
             "year"
           ],
-          "repeat": false,
           "required": true,
           "fixedFacets": {
             "format": 1332
@@ -104,9 +91,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -124,15 +108,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -148,15 +128,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -178,15 +154,11 @@
                 "type": [
                   "year"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Facets/test003/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Facets/test003/api-tck.json
@@ -14,15 +14,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Facets/test004/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Facets/test004/api-tck.json
@@ -24,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +40,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -70,15 +62,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -94,15 +82,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -124,15 +108,11 @@
                 "type": [
                   "myDate"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -146,15 +126,11 @@
                 "type": [
                   "YYYY"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Facets/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Facets/test005/api-tck.json
@@ -24,15 +24,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +40,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -70,15 +62,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -94,15 +82,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -124,15 +108,11 @@
                 "type": [
                   "myDate"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -146,15 +126,11 @@
                 "type": [
                   "YYYY"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -173,15 +149,11 @@
                 "type": [
                   "year"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -195,7 +167,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -203,9 +174,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test001/oType01-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test001/oType01-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "initial_comments": "oo"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -22,15 +21,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +39,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -66,9 +57,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
@@ -17,7 +17,6 @@
             "time_stamp": 1422378528,
             "created": 1422378528
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -26,15 +25,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -48,15 +43,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -92,15 +79,11 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -137,9 +116,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test004/oType04-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test004/oType04-tck.json
@@ -15,7 +15,6 @@
             "user": "Raml",
             "time_stamp": 1422378528
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -24,15 +23,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -43,15 +38,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -65,15 +56,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -87,15 +74,11 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -109,15 +92,11 @@
               "type": [
                 "integer"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -132,9 +111,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test005/oType05-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test005/oType05-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,7 +36,6 @@
               "type": [
                 "string"
               ],
-              "repeat": true,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -61,9 +55,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test005/oType05.raml
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test005/oType05.raml
@@ -9,4 +9,3 @@ types:
       comment_id?: number
       initial_comments?:
         type: string
-        repeat: true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test006/oType06-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test006/oType06-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "comment_id": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,15 +37,11 @@
                 "string"
               ],
               "default": "Initial commint",
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -65,9 +56,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test007/oType07-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test007/oType07-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "Person"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -67,15 +58,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test008/oType08-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test008/oType08-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "email": {
@@ -67,15 +58,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -107,7 +91,6 @@
             "Person",
             "EmailOwner"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -116,15 +99,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -137,9 +116,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test009/oType09-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test009/oType09-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "count": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test010/oType10-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test010/oType10-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "[]": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test011/oType11-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test011/oType11-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "[a-zA-Z]": {
@@ -19,15 +18,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test012/oType12-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test012/oType12-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,16 +50,12 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "additionalProperties": false,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test013/oType13-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test013/oType13-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -66,7 +58,6 @@
               "name": "create method"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "/post|get|put/": {
@@ -75,15 +66,11 @@
               "type": [
                 "Method"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -96,9 +83,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test014/oType14-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test014/oType14-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test015/oType15-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test015/oType15-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test016/oType16-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test016/oType16-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test017/oType17-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test017/oType17-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test018/api-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test018/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "eleo"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +39,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test019/api-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test019/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "eleo"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +39,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -65,9 +56,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test020/api-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test020/api-tck.json
@@ -14,7 +14,6 @@
             "firstname": "eleo",
             "lastname": "ortega"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "firstname": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,15 +40,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -67,15 +58,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -88,9 +75,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test021/api-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test021/api-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "eleo"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +39,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/ObjectTypes/test022/api-tck.json
+++ b/src/source/TCK/RAML10/Types/ObjectTypes/test022/api-tck.json
@@ -14,7 +14,6 @@
             "name": "eleo",
             "title??": "Yes, I have a title"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -23,15 +22,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -45,15 +40,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -63,9 +54,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test001/test1-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test001/test1-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "type": {
@@ -19,7 +18,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "Feature"
@@ -28,9 +26,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -44,15 +39,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -66,15 +57,11 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -87,9 +74,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -105,7 +89,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "_embeds": {
@@ -114,16 +97,12 @@
               "type": [
                 "object[]"
               ],
-              "repeat": false,
               "required": false,
               "description": "Optional embedded, related resources if requested.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -137,16 +116,12 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": false,
               "description": "Optional links to related resources.",
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   }
                 }
               }
@@ -158,9 +133,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -178,7 +150,6 @@
             "ZoomEmbed",
             "Feature"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -187,15 +158,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -208,9 +175,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -226,7 +190,6 @@
           "type": [
             "Scene"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "properties": {
@@ -235,15 +198,11 @@
               "type": [
                 "PlanetProperties"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -257,7 +216,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "description": "Links to related resources and actions.",
               "properties": {
@@ -267,15 +225,11 @@
                   "type": [
                     "ResourceURL"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -289,9 +243,6 @@
                   "displayName": {
                     "calculated": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -303,9 +254,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -321,7 +269,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "acquired": {
@@ -330,15 +277,11 @@
               "type": [
                 "datetime"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -355,9 +298,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -372,7 +312,6 @@
           "type": [
             "BaseProperties"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "vnd_camera_gain": {
@@ -381,16 +320,12 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "minimum": 0,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -403,9 +338,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -421,16 +353,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "description": "A URL to a related resource.",
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -516,15 +444,11 @@
                                 }
                               }
                             ],
-                            "repeat": false,
                             "required": true,
                             "__METADATA__": {
                               "primitiveValuesMeta": {
                                 "displayName": {
                                   "calculated": true
-                                },
-                                "repeat": {
-                                  "insertedAsDefault": true
                                 },
                                 "required": {
                                   "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test002/test2-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test002/test2-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -91,9 +78,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -109,7 +93,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name3": {
@@ -118,15 +101,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -160,7 +136,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -169,15 +144,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -194,9 +165,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -211,7 +179,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -220,15 +187,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -241,9 +204,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test003/test3-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test003/test3-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -61,7 +53,6 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name2": {
@@ -70,15 +61,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -91,9 +78,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -109,7 +93,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -118,15 +101,11 @@
               "type": [
                 "boolean"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -160,7 +136,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -169,15 +144,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -194,9 +165,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -211,7 +179,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -220,15 +187,11 @@
               "type": [
                 "PropertyType3"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -241,9 +204,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test004/test4-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test004/test4-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maxLength": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test005/test5-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test005/test5-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maxLength": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test006/test6-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test006/test6-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maxLength": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test007/test7-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test007/test7-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maxLength": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test008/test8-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test008/test8-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "minimum": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maximum": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test009/test9-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test009/test9-tck.json
@@ -14,15 +14,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -34,7 +30,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
@@ -42,9 +37,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -65,15 +57,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -85,15 +73,11 @@
           "type": [
             "SuperType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/PropertyOverride/test010/test10-tck.json
+++ b/src/source/TCK/RAML10/Types/PropertyOverride/test010/test10-tck.json
@@ -10,16 +10,12 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 0,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -35,16 +31,12 @@
           "type": [
             "PropertyType1"
           ],
-          "repeat": false,
           "required": true,
           "maxLength": 5,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -60,7 +52,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -69,15 +60,11 @@
               "type": [
                 "PropertyType1"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -94,9 +81,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -111,7 +95,6 @@
           "type": [
             "Type1"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "testProperty": {
@@ -120,15 +103,11 @@
               "type": [
                 "PropertyType2"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -141,9 +120,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test001/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test001/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "Person"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test002/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test002/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "Person[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test003/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test003/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test004/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test004/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string[][]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test005/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test005/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "Person | string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test006/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test006/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "(Person | string)[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test007/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test007/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "manufacturer": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -80,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "manufacturer": {
@@ -89,15 +76,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -111,15 +94,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -132,9 +111,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -150,7 +126,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "devices": {
@@ -159,15 +134,11 @@
               "type": [
                 "( Phone | Notebook )[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -181,15 +152,11 @@
               "type": [
                 "Person[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -202,9 +169,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/Type Expressions/test008/api-tck.json
+++ b/src/source/TCK/RAML10/Types/Type Expressions/test008/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "manufacturer": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -62,9 +53,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -80,7 +68,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "manufacturer": {
@@ -89,15 +76,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -111,15 +94,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -132,9 +111,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -150,15 +126,11 @@
           "type": [
             "( Phone | Notebook )[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test001/apiValid-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "somestring"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test002/apiInvalid-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "somestring"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -73,7 +65,6 @@
             "name1": "somestring",
             "age": "stringValue"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -82,15 +73,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -103,9 +90,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test002/apiValid-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "somestring"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -73,7 +65,6 @@
             "name": "somestring",
             "age": 11
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -82,15 +73,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -103,9 +90,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test003/apiInvalid-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "somestring"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,7 +61,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -78,15 +69,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -102,9 +89,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -127,7 +111,6 @@
               "age": "123s"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "someProperty": {
@@ -136,15 +119,11 @@
               "type": [
                 "AnotherType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -157,9 +136,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test003/apiValid-tck.json
@@ -13,7 +13,6 @@
           "example": {
             "name": "somestring"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -22,15 +21,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -43,9 +38,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -69,7 +61,6 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -78,15 +69,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -100,9 +87,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -124,7 +108,6 @@
               "age": 123
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "someProperty": {
@@ -133,15 +116,11 @@
               "type": [
                 "AnotherType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -154,9 +133,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test004/apiInvalid-tck.json
@@ -14,15 +14,11 @@
             100500,
             "not number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test004/apiValid-tck.json
@@ -14,15 +14,11 @@
             "some string",
             "another string"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test005/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -67,15 +58,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -89,9 +76,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -122,7 +106,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "users": {
@@ -131,15 +114,11 @@
               "type": [
                 "AnotherType[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -154,9 +133,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test005/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,7 +50,6 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "age": {
@@ -67,15 +58,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -89,9 +76,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -119,7 +103,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "users": {
@@ -128,15 +111,11 @@
               "type": [
                 "AnotherType[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -151,9 +130,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/test006/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test006/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property3": {
@@ -92,15 +79,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -190,7 +162,6 @@
               "property4": "blahblah"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "union1": {
@@ -199,15 +170,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -221,15 +188,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -242,9 +205,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test006/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test006/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property3": {
@@ -92,15 +79,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -190,7 +162,6 @@
               "property4": "blahblah"
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "union1": {
@@ -199,15 +170,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -221,15 +188,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -242,9 +205,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test007/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test007/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string[] | number[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -46,7 +42,6 @@
               "blah"
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray1": {
@@ -55,15 +50,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,15 +68,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -98,9 +85,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test007/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test007/apiValid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "string[] | number[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -46,7 +42,6 @@
               "blah"
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray1": {
@@ -55,15 +50,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,15 +68,11 @@
               "type": [
                 "SimpleUnion"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -98,9 +85,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test008/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test008/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property3": {
@@ -92,15 +79,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -192,7 +164,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray": {
@@ -201,15 +172,11 @@
               "type": [
                 "SimpleUnion[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -222,9 +189,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test008/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test008/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property3": {
@@ -92,15 +79,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -192,7 +164,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray": {
@@ -201,15 +172,11 @@
               "type": [
                 "SimpleUnion[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -222,9 +189,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test009/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test009/apiInvalid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -92,15 +79,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -192,7 +164,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray": {
@@ -201,15 +172,11 @@
               "type": [
                 "SimpleUnion[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -222,9 +189,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test009/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test009/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -41,15 +36,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -64,9 +55,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -83,7 +71,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "property1": {
@@ -92,15 +79,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -114,15 +97,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -139,9 +118,6 @@
               "type": {
                 "insertedAsDefault": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -156,15 +132,11 @@
           "type": [
             "SimpleType1 | SimpleType2"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -192,7 +164,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "unionArray": {
@@ -201,15 +172,11 @@
               "type": [
                 "SimpleUnion[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -222,9 +189,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test010/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test010/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,15 +50,11 @@
           "type": [
             "SomeType[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -92,7 +80,6 @@
               }
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop": {
@@ -101,15 +88,11 @@
               "type": [
                 "ArrayType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -122,9 +105,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test011/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test011/apiValid-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "name": {
@@ -19,15 +18,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -40,9 +35,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,15 +50,11 @@
           "type": [
             "string[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -88,7 +76,6 @@
               "val2"
             ]
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "prop": {
@@ -97,15 +84,11 @@
               "type": [
                 "ArrayType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -118,9 +101,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test012/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test012/apiInvalid-tck.json
@@ -24,7 +24,6 @@
             ],
             "someProperty": "val3"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "selfReference": {
@@ -33,15 +32,11 @@
               "type": [
                 "SomeType[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -55,15 +50,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test012/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test012/apiValid-tck.json
@@ -24,7 +24,6 @@
             ],
             "someProperty": "stringValue"
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "selfReference": {
@@ -33,15 +32,11 @@
               "type": [
                 "SomeType[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -55,15 +50,11 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -77,9 +68,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test013/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test013/apiInvalid-tck.json
@@ -17,7 +17,6 @@
               }
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "someProperty": {
@@ -26,15 +25,11 @@
               "type": [
                 "SomeType"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -49,9 +44,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/test013/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/test013/apiValid-tck.json
@@ -17,7 +17,6 @@
               }
             }
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "someProperty": {
@@ -26,15 +25,11 @@
               "type": [
                 "SomeType?"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -49,9 +44,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {

--- a/src/source/TCK/RAML10/Types/test014/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test014/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "SomeType[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test015/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test015/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test016/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test016/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "OneMoreType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,15 +50,11 @@
           "type": [
             "AnotherType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test017/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/test017/apiInvalid-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "object | SomeUnion"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,15 +30,11 @@
           "type": [
             "AnotherType[] | OneMoreType[]"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -58,15 +50,11 @@
           "type": [
             "SomeType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -82,15 +70,11 @@
           "type": [
             "AnotherType"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test018/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test018/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "string"
           ],
-          "repeat": false,
           "required": true,
           "minLength": 1,
           "maxLength": 10,
@@ -18,9 +17,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test019/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test019/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "number"
           ],
-          "repeat": false,
           "required": true,
           "minimum": 10,
           "maximum": 1,
@@ -18,9 +17,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test020/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test020/api-tck.json
@@ -10,7 +10,6 @@
           "type": [
             "integer"
           ],
-          "repeat": false,
           "required": true,
           "minimum": 1,
           "maximum": 1,
@@ -18,9 +17,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test021/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test021/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "boolean"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test022/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test022/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "datetime"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test023/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test023/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "file"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test024/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test024/api-tck.json
@@ -11,15 +11,11 @@
             "number"
           ],
           "example": 630128,
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -48,7 +44,6 @@
             "house": "77, Suite 400",
             "zip": 94108
           },
-          "repeat": false,
           "required": true,
           "properties": {
             "country": {
@@ -57,7 +52,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "enum": [
                 "US",
@@ -73,9 +67,6 @@
                   "type": {
                     "insertedAsDefault": true
                   },
-                  "repeat": {
-                    "insertedAsDefault": true
-                  },
                   "required": {
                     "insertedAsDefault": true
                   }
@@ -88,7 +79,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -96,9 +86,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -113,7 +100,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -121,9 +107,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -138,7 +121,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -146,9 +128,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -163,15 +142,11 @@
               "type": [
                 "Zip"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -186,9 +161,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -218,7 +190,6 @@
             "string"
           ],
           "example": "press@mulesoft.com",
-          "repeat": false,
           "required": true,
           "pattern": "[a-zA-Z0-9\\.]{1,32}@[a-zA-Z0-9]+\\.com",
           "minLength": 15,
@@ -229,9 +200,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -259,7 +227,6 @@
                 "string"
               ],
               "default": "user",
-              "repeat": false,
               "required": true,
               "enum": [
                 "user",
@@ -273,9 +240,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -320,7 +284,6 @@
               }
             }
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -329,15 +292,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -351,7 +310,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
@@ -359,9 +317,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -376,15 +331,11 @@
               "type": [
                 "Email"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -398,7 +349,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": false,
               "pattern": "\\+\\d{1}\\-\\d{3}\\-\\d{3}\\-\\d{4}",
               "minLength": 15,
@@ -409,9 +359,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -426,15 +373,11 @@
               "type": [
                 "Address"
               ],
-              "repeat": false,
               "required": false,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -449,9 +392,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -504,7 +444,6 @@
               }
             }
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "managerId": {
@@ -513,15 +452,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -538,9 +473,6 @@
               "displayName": {
                 "calculated": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -555,7 +487,6 @@
           "type": [
             "User"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "adminId": {
@@ -564,15 +495,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -589,9 +516,6 @@
               "displayName": {
                 "calculated": true
               },
-              "repeat": {
-                "insertedAsDefault": true
-              },
               "required": {
                 "insertedAsDefault": true
               }
@@ -606,15 +530,11 @@
           "type": [
             "Admin"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -630,7 +550,6 @@
           "type": [
             "object"
           ],
-          "repeat": false,
           "required": true,
           "properties": {
             "id": {
@@ -639,15 +558,11 @@
               "type": [
                 "number"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -661,7 +576,6 @@
               "type": [
                 "string"
               ],
-              "repeat": false,
               "required": true,
               "pattern": "/[A-Z][a-z]*/",
               "__METADATA__": {
@@ -670,9 +584,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -687,15 +598,11 @@
               "type": [
                 "Manager"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -709,15 +616,11 @@
               "type": [
                 "Admin|SuperAdmin"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -731,15 +634,11 @@
               "type": [
                 "(User|Team)[]"
               ],
-              "repeat": false,
               "required": true,
               "__METADATA__": {
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true
@@ -753,7 +652,6 @@
               "type": [
                 "object"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "address": {
@@ -762,15 +660,11 @@
                   "type": [
                     "Address"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -784,15 +678,11 @@
                   "type": [
                     "Email"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -806,15 +696,11 @@
                   "type": [
                     "number"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
                       "displayName": {
                         "calculated": true
-                      },
-                      "repeat": {
-                        "insertedAsDefault": true
                       },
                       "required": {
                         "insertedAsDefault": true
@@ -829,9 +715,6 @@
                     "calculated": true
                   },
                   "type": {
-                    "insertedAsDefault": true
-                  },
-                  "repeat": {
                     "insertedAsDefault": true
                   },
                   "required": {
@@ -847,9 +730,6 @@
                 "calculated": true
               },
               "type": {
-                "insertedAsDefault": true
-              },
-              "repeat": {
                 "insertedAsDefault": true
               },
               "required": {
@@ -870,7 +750,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -882,9 +761,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -914,15 +790,11 @@
                     "type": [
                       "Team[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -956,7 +828,6 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "fixedFacets": {
                       "role": "admin"
@@ -965,9 +836,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -985,7 +853,6 @@
                 "type": [
                   "object"
                 ],
-                "repeat": false,
                 "required": true,
                 "properties": {
                   "title": {
@@ -994,7 +861,6 @@
                     "type": [
                       "string"
                     ],
-                    "repeat": false,
                     "required": true,
                     "pattern": "[A-Z][a-z]*",
                     "__METADATA__": {
@@ -1003,9 +869,6 @@
                           "calculated": true
                         },
                         "type": {
-                          "insertedAsDefault": true
-                        },
-                        "repeat": {
                           "insertedAsDefault": true
                         },
                         "required": {
@@ -1021,9 +884,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -1063,15 +923,11 @@
                         "type": [
                           "Team"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
                             "displayName": {
                               "calculated": true
-                            },
-                            "repeat": {
-                              "insertedAsDefault": true
                             },
                             "required": {
                               "insertedAsDefault": true
@@ -1090,7 +946,6 @@
                         "type": [
                           "object"
                         ],
-                        "repeat": false,
                         "required": true,
                         "__METADATA__": {
                           "primitiveValuesMeta": {
@@ -1098,9 +953,6 @@
                               "calculated": true
                             },
                             "type": {
-                              "insertedAsDefault": true
-                            },
-                            "repeat": {
                               "insertedAsDefault": true
                             },
                             "required": {
@@ -1132,7 +984,6 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "calculated": true,
@@ -1141,9 +992,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -1191,15 +1039,11 @@
                     "type": [
                       "User[]"
                     ],
-                    "repeat": false,
                     "required": true,
                     "__METADATA__": {
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -1249,7 +1093,6 @@
                     "type": [
                       "User"
                     ],
-                    "repeat": false,
                     "required": true,
                     "fixedFacets": {
                       "role": "admin"
@@ -1258,9 +1101,6 @@
                       "primitiveValuesMeta": {
                         "displayName": {
                           "calculated": true
-                        },
-                        "repeat": {
-                          "insertedAsDefault": true
                         },
                         "required": {
                           "insertedAsDefault": true
@@ -1291,7 +1131,6 @@
             "type": [
               "string"
             ],
-            "repeat": false,
             "required": true,
             "__METADATA__": {
               "calculated": true,
@@ -1300,9 +1139,6 @@
                   "calculated": true
                 },
                 "type": {
-                  "insertedAsDefault": true
-                },
-                "repeat": {
                   "insertedAsDefault": true
                 },
                 "required": {

--- a/src/source/TCK/RAML10/Types/test025/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test025/api-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "{\n  \"type\": \"object\",\n  \"properties\": [\n    {\n      \"name\": \"string\"\n    }\n  ]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -36,15 +32,11 @@
           "type": [
             "{\n  \"type\": \"object\",\n  \"properties\": [\n    {\n      \"name\": \"string\"\n    }\n  ]\n}\n"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test026/api-tck.json
+++ b/src/source/TCK/RAML10/Types/test026/api-tck.json
@@ -12,7 +12,6 @@
         "type": [
           "string"
         ],
-        "repeat": false,
         "required": true,
         "enum": [
           "v1"
@@ -24,9 +23,6 @@
               "calculated": true
             },
             "type": {
-              "insertedAsDefault": true
-            },
-            "repeat": {
               "insertedAsDefault": true
             },
             "required": {
@@ -50,7 +46,6 @@
               "application/xml": {
                 "name": "application/xml",
                 "displayName": "application/xml",
-                "repeat": false,
                 "required": true,
                 "type": {
                   "name": "type",
@@ -58,7 +53,6 @@
                   "type": [
                     "object"
                   ],
-                  "repeat": false,
                   "required": true,
                   "properties": {
                     "prop1": {
@@ -67,15 +61,11 @@
                       "type": [
                         "string"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -89,15 +79,11 @@
                       "type": [
                         "number"
                       ],
-                      "repeat": false,
                       "required": true,
                       "__METADATA__": {
                         "primitiveValuesMeta": {
                           "displayName": {
                             "calculated": true
-                          },
-                          "repeat": {
-                            "insertedAsDefault": true
                           },
                           "required": {
                             "insertedAsDefault": true
@@ -114,9 +100,6 @@
                       "type": {
                         "insertedAsDefault": true
                       },
-                      "repeat": {
-                        "insertedAsDefault": true
-                      },
                       "required": {
                         "insertedAsDefault": true
                       }
@@ -127,9 +110,6 @@
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -175,15 +155,11 @@
                   "string",
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -229,7 +205,6 @@
                   "string",
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -237,9 +212,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -285,7 +257,6 @@
                 "schema": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
@@ -293,9 +264,6 @@
                       "calculated": true
                     },
                     "type": {
-                      "insertedAsDefault": true
-                    },
-                    "repeat": {
                       "insertedAsDefault": true
                     },
                     "required": {
@@ -341,15 +309,11 @@
                 "type": [
                   "string"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true
@@ -394,15 +358,11 @@
                 "schema": [
                   "number"
                 ],
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test027/lib-tck.json
+++ b/src/source/TCK/RAML10/Types/test027/lib-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "integer|number"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true
@@ -34,7 +30,6 @@
           "type": [
             "Foo"
           ],
-          "repeat": false,
           "required": true,
           "fixedFacets": {
             "maximum": 2,
@@ -44,9 +39,6 @@
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test028/lib-tck.json
+++ b/src/source/TCK/RAML10/Types/test028/lib-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "null"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test029/lib-tck.json
+++ b/src/source/TCK/RAML10/Types/test029/lib-tck.json
@@ -12,7 +12,6 @@
               "type": [
                 "<<param>>"
               ],
-              "repeat": false,
               "required": true,
               "properties": {
                 "prop1": {
@@ -21,7 +20,6 @@
                   "type": [
                     "string"
                   ],
-                  "repeat": false,
                   "required": true,
                   "__METADATA__": {
                     "primitiveValuesMeta": {
@@ -29,9 +27,6 @@
                         "calculated": true
                       },
                       "type": {
-                        "insertedAsDefault": true
-                      },
-                      "repeat": {
                         "insertedAsDefault": true
                       },
                       "required": {
@@ -45,9 +40,6 @@
                 "primitiveValuesMeta": {
                   "displayName": {
                     "calculated": true
-                  },
-                  "repeat": {
-                    "insertedAsDefault": true
                   },
                   "required": {
                     "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/test030/lib-tck.json
+++ b/src/source/TCK/RAML10/Types/test030/lib-tck.json
@@ -10,15 +10,11 @@
           "type": [
             "null"
           ],
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test001/apiInvalid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n<xs:element name=\"c2NoZW1hLnhzZC9jb3VudHJ5\" originalname=\"country\" requestedname=\"country\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test001/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test001/apiValid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n<xs:element name=\"c2NoZW1hLnhzZC9jb3VudHJ5\" originalname=\"country\" requestedname=\"country\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<country><country_name>France</country_name>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test002/apiInvalid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n<xs:element name=\"c2NoZW1hLnhzZC9DaXR5\" type=\"City\" requestedname=\"City\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test002/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test002/apiValid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n<xs:element name=\"c2NoZW1hLnhzZC9DaXR5\" type=\"City\" requestedname=\"City\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<country><country_name>France</country_name>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test003/apiInvalid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n<xs:element name=\"c2NoZW1hLnhzZC9jaXR5\" type=\"City\" originalname=\"city\" requestedname=\"city\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test003/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test003/apiValid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n<xs:element name=\"c2NoZW1hLnhzZC9jaXR5\" type=\"City\" originalname=\"city\" requestedname=\"city\" extraelement=\"true\"/></xs:schema>"
                 ],
                 "example": "<city><country_name>France</country_name>\n<population>59.7</population></city>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test004/apiInvalid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n<xs:element name=\"c2NoZW1hLnhzZC9jb3VudHJ5\" originalname=\"country\" requestedname=\"country\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test004/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test004/apiValid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n<xs:element name=\"c2NoZW1hLnhzZC9jb3VudHJ5\" originalname=\"country\" requestedname=\"country\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<country><country_name>France</country_name>\n<population>59.7</population></country>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test005/apiInvalid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n<xs:element name=\"c2NoZW1hLnhzZC9DaXR5\" type=\"City\" requestedname=\"City\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test005/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test005/apiValid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n<xs:element name=\"c2NoZW1hLnhzZC9DaXR5\" type=\"City\" requestedname=\"City\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<country><country_name>France</country_name>\n<population>59.7</population></country>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test006/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test006/apiInvalid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n<xs:element name=\"c2NoZW1hLnhzZC8\" requestedname=\"\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test006/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test006/apiValid-tck.json
@@ -11,15 +11,11 @@
             "<?xml version=\"1.0\" encoding=\"utf-8\"?><xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name=\"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n<xs:element name=\"c2NoZW1hLnhzZC9jaXR5\" type=\"City\" originalname=\"city\" requestedname=\"city\" extraelement=\"true\"/></xs:schema>"
           ],
           "example": "<city><country_name>France</country_name>\n<population>59.7</population></city>\n",
-          "repeat": false,
           "required": true,
           "__METADATA__": {
             "primitiveValuesMeta": {
               "displayName": {
                 "calculated": true
-              },
-              "repeat": {
-                "insertedAsDefault": true
               },
               "required": {
                 "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test007/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test007/apiInvalid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name = \"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n</xs:schema>\n"
                 ],
                 "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test007/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test007/apiValid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name = \"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n</xs:schema>\n"
                 ],
                 "example": "<city><country_name>France</country_name>\n<population>59.7</population></city>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test008/apiInvalid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test008/apiInvalid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name = \"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n</xs:schema>\n"
                 ],
                 "example": "<country><country_name1>France</country_name1>\n<population>59.7</population></country>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true

--- a/src/source/TCK/RAML10/Types/xsdscheme/test008/apiValid-tck.json
+++ b/src/source/TCK/RAML10/Types/xsdscheme/test008/apiValid-tck.json
@@ -15,15 +15,11 @@
                   "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"country\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"country_name\" type=\"xs:string\"/>\n        <xs:element name=\"population\" type=\"xs:decimal\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n  <xs:complexType name = \"City\">\n    <xs:sequence>\n      <xs:element name=\"country_name\" type=\"xs:string\"/>\n      <xs:element name=\"population\" type=\"xs:decimal\"/>\n    </xs:sequence>\n  </xs:complexType>\n  <xs:element name=\"city\" type=\"City\"/>\n</xs:schema>\n"
                 ],
                 "example": "<city><country_name>France</country_name>\n<population>59.7</population></city>\n",
-                "repeat": false,
                 "required": true,
                 "__METADATA__": {
                   "primitiveValuesMeta": {
                     "displayName": {
                       "calculated": true
-                    },
-                    "repeat": {
-                      "insertedAsDefault": true
                     },
                     "required": {
                       "insertedAsDefault": true


### PR DESCRIPTION
Issues fixed:
- removing 20x like response codes
- removing "repeat" keyword
- removing "patternProperties" keyword
