### PR TITLE
Use last overlay or extension for raml input

### DIFF
--- a/src/source/TCK/RAML10/Overlays/test009/NewOverlay2.raml
+++ b/src/source/TCK/RAML10/Overlays/test009/NewOverlay2.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Overlay
 title: Overlay2
-extends: api.raml
+extends: NewOverlay.raml
 
 /resource:
   displayName: "Test3"

--- a/src/source/TCK/RAML10/Overlays/test009/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test009/api-tck.json
@@ -26,7 +26,7 @@
         ]
       }
     ],
-    "extends": "api.raml"
+    "extends": "NewOverlay.raml"
   },
   "errors": [
     {
@@ -35,17 +35,17 @@
       "path": "NewOverlay2.raml",
       "line": 6,
       "column": 0,
-      "position": 88,
+      "position": 95,
       "range": [
         {
           "line": 6,
           "column": 0,
-          "position": 88
+          "position": 95
         },
         {
           "line": 6,
           "column": 16,
-          "position": 104
+          "position": 111
         }
       ]
     }

--- a/src/source/TCK/RAML10/Overlays/test010/NewExtension2.raml
+++ b/src/source/TCK/RAML10/Overlays/test010/NewExtension2.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Extension
 title: Extension
-extends: api.raml
+extends: NewOverlay.raml
 
 /resource:
   displayName: "Test3"

--- a/src/source/TCK/RAML10/Overlays/test010/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test010/api-tck.json
@@ -26,7 +26,7 @@
         ]
       }
     ],
-    "extends": "api.raml"
+    "extends": "NewOverlay.raml"
   },
   "errors": []
 }

--- a/src/source/TCK/RAML10/Overlays/test011/NewExtension3.raml
+++ b/src/source/TCK/RAML10/Overlays/test011/NewExtension3.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Extension
 title: Extension
-extends: NewOverlay2.raml
+extends: NewExtension2.raml
 
 /resource:
   displayName: "Test4"

--- a/src/source/TCK/RAML10/Overlays/test011/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test011/api-tck.json
@@ -40,7 +40,7 @@
         ]
       }
     ],
-    "extends": "NewOverlay2.raml"
+    "extends": "NewExtension2.raml"
   },
   "errors": []
 }

--- a/src/source/TCK/RAML10/Overlays/test023/NewOverlay2.raml
+++ b/src/source/TCK/RAML10/Overlays/test023/NewOverlay2.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Overlay
 title: Extension2
-extends: api.raml
+extends: NewOverlay.raml
 traits:
   env-org-pair:
       displayName: overlayDisplayName2

--- a/src/source/TCK/RAML10/Overlays/test023/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test023/api-tck.json
@@ -78,7 +78,7 @@
         ]
       }
     ],
-    "extends": "api.raml"
+    "extends": "NewOverlay.raml"
   },
   "errors": []
 }

--- a/src/source/TCK/RAML10/Overlays/test024/NewOverlay2.raml
+++ b/src/source/TCK/RAML10/Overlays/test024/NewOverlay2.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Overlay
 title: Extension2
-extends: api.raml
+extends: NewOverlay.raml
 traits:
   env-org-pair:
       displayName: overlayDisplayName2

--- a/src/source/TCK/RAML10/Overlays/test024/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test024/api-tck.json
@@ -78,7 +78,7 @@
         ]
       }
     ],
-    "extends": "api.raml"
+    "extends": "NewOverlay.raml"
   },
   "errors": []
 }

--- a/src/source/TCK/RAML10/Overlays/test025/NewOverlay2.raml
+++ b/src/source/TCK/RAML10/Overlays/test025/NewOverlay2.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 Overlay
 title: Overlay 2
-extends: api.raml
+extends: NewOverlay.raml
 
 uses:
   lib:  lib.raml

--- a/src/source/TCK/RAML10/Overlays/test025/api-tck.json
+++ b/src/source/TCK/RAML10/Overlays/test025/api-tck.json
@@ -38,7 +38,7 @@
         ]
       }
     ],
-    "extends": "api.raml"
+    "extends": "NewOverlay.raml"
   },
   "errors": []
 }

--- a/src/source/parsers/jsparser/tckUtil.js
+++ b/src/source/parsers/jsparser/tckUtil.js
@@ -187,9 +187,8 @@ function getTests(dirContent) {
     else if (dirContent.hasExtensionsOrOverlaysAppliedToSingleAPI()) {
         var ordered = orderExtensionsAndOverlays(dirContent.extnsionsAndOverlays());
         if (ordered) {
-            var apiPath = ordered[0].extends();
-            var extensionsAndOverlays = ordered.map(function (x) { return x.absolutePath(); });
-            result = [new Test(apiPath, extensionsAndOverlays)];
+            var lastOverlayOrExtension = ordered[ordered.length - 1];
+            result = [new Test(lastOverlayOrExtension.absolutePath(), null, defaultJSONPath(ordered[0].extends()))];
         }
     }
     return result;


### PR DESCRIPTION
I changed the tckUtil class to use the last overlay or extension as input raml instead of the raml api. Let me know if I should make any change. 
