### PR TITLE
Fix additional property regex

### DIFF
--- a/src/source/TCK/RAML10/Overlays/test026/aws-lib.raml
+++ b/src/source/TCK/RAML10/Overlays/test026/aws-lib.raml
@@ -8,7 +8,7 @@ types:
     pattern: "^[12345]\\d\\d$"
   amazon-apigateway-templates:
     properties:
-      /"\\w+/\\w+"/:
+      /\w+/\w+/:
   amazon-apigateway-auth-type:
     enum: [ aws_iam ]
   amazon-apigateway-integration-lambda:


### PR DESCRIPTION
escaping with double backslashes is required only when the yaml string nodes are enclosed with quotes:
e.g:

| properties pattern | valid |
| --- | --- |
| `/\w+/\w+/` | :white_check_mark: |
| `"/\\w+/\\w+/"` | :white_check_mark: |
| `/\\w+/\\w+/` | :x: |
| `"/\w+/\w+/"` | :x: |
