### PR TITLE
For raml 0.8 invalid examples produce warnings instead errors

### DIFF
--- a/src/source/TCK/RAML08/Instagram/api-tck.json
+++ b/src/source/TCK/RAML08/Instagram/api-tck.json
@@ -5123,7 +5123,8 @@
           "column": 21,
           "position": 2461
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -5143,7 +5144,8 @@
           "column": 23,
           "position": 5648
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -5163,7 +5165,8 @@
           "column": 19,
           "position": 15295
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/ResourceTypes/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/ResourceTypes/test001/apiInvalid-tck.json
@@ -192,7 +192,8 @@
           "column": 15,
           "position": 282
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/ResourceTypes/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/ResourceTypes/test002/apiInvalid-tck.json
@@ -192,7 +192,8 @@
           "column": 15,
           "position": 282
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/ResourceTypes/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/ResourceTypes/test003/apiInvalid-tck.json
@@ -233,7 +233,8 @@
           "column": 19,
           "position": 633
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/ResourceTypes/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/ResourceTypes/test004/apiInvalid-tck.json
@@ -316,7 +316,8 @@
           "column": 15,
           "position": 781
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -336,7 +337,8 @@
           "column": 15,
           "position": 842
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -356,7 +358,8 @@
           "column": 19,
           "position": 947
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/ResourceTypes/test005/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/ResourceTypes/test005/apiInvalid-tck.json
@@ -316,7 +316,8 @@
           "column": 15,
           "position": 781
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -336,7 +337,8 @@
           "column": 15,
           "position": 850
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/Traits/test001/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/Traits/test001/apiInvalid-tck.json
@@ -109,7 +109,8 @@
           "column": 15,
           "position": 209
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/Traits/test002/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/Traits/test002/apiInvalid-tck.json
@@ -197,7 +197,8 @@
           "column": 15,
           "position": 391
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/Traits/test003/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/Traits/test003/apiInvalid-tck.json
@@ -197,7 +197,8 @@
           "column": 15,
           "position": 362
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/source/TCK/RAML08/Traits/test004/apiInvalid-tck.json
+++ b/src/source/TCK/RAML08/Traits/test004/apiInvalid-tck.json
@@ -169,7 +169,8 @@
           "column": 15,
           "position": 353
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,
@@ -189,7 +190,8 @@
           "column": 15,
           "position": 397
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }


### PR DESCRIPTION
Contributing changes according to https://github.com/raml-org/raml-js-parser-2/issues/421 fix
