### PR TITLE
Add invalid case for optional discriminator

### DIFF
--- a/tests/raml-1.0/Types/ObjectTypes/discriminator/invalid-optional-discriminator.raml
+++ b/tests/raml-1.0/Types/ObjectTypes/discriminator/invalid-optional-discriminator.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: API
+
+types:
+  Person:
+    type: object
+    discriminator: optionalProperty
+    properties:
+      name: string
+      surname: string
+      optionalProperty?: string


### PR DESCRIPTION
Discriminator properties should always be required. Setting an optional property as discriminator should be invalid. Added a case showing that.