### PR TITLE
Update valid.raml to use map instead of array

### DIFF
--- a/tests/raml-1.0/Types/types-and-schemas/valid.raml
+++ b/tests/raml-1.0/Types/types-and-schemas/valid.raml
@@ -6,9 +6,9 @@ types:
   Player1: |
      {
        "type": "object",
-       "properties": [
-         {
-           "name": "string"
+       "properties": {
+         "name": {
+           "type": "string"
          }
-       ]
+       }
      }


### PR DESCRIPTION
As stated in RAML spec (https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#property-declarations), "The properties declaration is a map of keys and values".