### PR TITLE
Fix: added json schema draft version to not depend on an implementations default version if  entry does not exist ons default version if  entry does not exist

### DIFF
--- a/tests/raml-1.0/Types/External Types/include-type-json-01/files/accountCorrect.json
+++ b/tests/raml-1.0/Types/External Types/include-type-json-01/files/accountCorrect.json
@@ -1,9 +1,10 @@
 {
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "type": "object",
   "properties": {
     "auth_token": {
       "required": false,
       "type": "string"
     }
-  },
-  "type": "object"
+  }
 }

--- a/tests/raml-1.0/Types/External Types/include-type-json-02/files/account.json
+++ b/tests/raml-1.0/Types/External Types/include-type-json-02/files/account.json
@@ -1,4 +1,7 @@
 {
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "type": "object",
+  "required": false,
   "properties": {
     "auth_token": {
       "required": false,
@@ -42,7 +45,5 @@
       "type": "object",
       "required": false
     }
-  },
-  "required": false,
-  "type": "object"
+  }
 }

--- a/tests/raml-1.0/Types/External Types/include-type-json-02/invalid-used-in-queryParameters.raml
+++ b/tests/raml-1.0/Types/External Types/include-type-json-02/invalid-used-in-queryParameters.raml
@@ -5,4 +5,4 @@ title: API
   get:
     queryParameters:
       year:
-        type: !include account.json
+        type: !include files/account.json


### PR DESCRIPTION
This PR adds $schema entries to avoid having the implementation decide which json schema draft to use. This is important as the schemas changed have `required` keys with boolean values which is only possible in draft 3.

Another option is to migrate all of these schemas to draft-4 but the $schema key should also be added.